### PR TITLE
feat: Add a few sensors for i35 humidifier.

### DIFF
--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -33,6 +33,7 @@ class DeviceAws(CallbacksMixin):
     filter_usage: int = None  # percentage
     wifi_working: bool = None
     wick_usage: int = None  # percentage
+    wick_dry_mode: bool = None
     wshortage: bool = None
     auto_regulated_humidity: int = None
 
@@ -75,6 +76,7 @@ class DeviceAws(CallbacksMixin):
         self.filter_usage = safely_get_json_value(states, "filterusage", int)
         self.wifi_working = safely_get_json_value(states, "online", bool)
         self.wick_usage = safely_get_json_value(states, "wickusage", int)
+        self.wick_dry_mode = safely_get_json_value(states, "wickdrys", bool)
         self.auto_regulated_humidity = safely_get_json_value(states, "autorh", int)
         self.water_shortage = safely_get_json_value(states, "wshortage", bool)
 
@@ -139,6 +141,7 @@ class DeviceAws(CallbacksMixin):
             "humidity": self.humidity,
             "filter_usage": self.filter_usage,
             "wick_usage": self.wick_usage,
+            "wick_dry_mode": self.wick_dry_mode,
             "auto_regulated_humidity": self.auto_regulated_humidity,
             "water_shortage": self.water_shortage,
         }

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -32,6 +32,9 @@ class DeviceAws(CallbacksMixin):
     humidity: int = None
     filter_usage: int = None  # percentage
     wifi_working: bool = None
+    wick_usage: int = None  # percentage
+    wshortage: bool = None
+    auto_regulated_humidity: int = None
 
     def __init__(
         self,
@@ -71,6 +74,9 @@ class DeviceAws(CallbacksMixin):
         self.fan_auto_mode = safely_get_json_value(states, "automode", bool)
         self.filter_usage = safely_get_json_value(states, "filterusage", int)
         self.wifi_working = safely_get_json_value(states, "online", bool)
+        self.wick_usage = safely_get_json_value(states, "wickusage", int)
+        self.auto_regulated_humidity = safely_get_json_value(states, "autorh", int)
+        self.water_shortage = safely_get_json_value(states, "wshortage", bool)
 
         self.publish_updates()
 
@@ -92,6 +98,11 @@ class DeviceAws(CallbacksMixin):
     async def set_fan_auto_mode(self, fan_auto_mode: bool):
         self.fan_auto_mode = fan_auto_mode
         await self.api.set_device_info(self.uuid, "automode", "vb", fan_auto_mode)
+        self.publish_updates()
+
+    async def set_auto_regulated_humidity(self, value: int):
+        self.auto_regulated_humidity = value
+        await self.api.set_device_info(self.uuid, "autorh", "v", value)
         self.publish_updates()
 
     async def set_child_lock(self, child_lock: bool):
@@ -127,6 +138,9 @@ class DeviceAws(CallbacksMixin):
             "temperature": self.temperature,
             "humidity": self.humidity,
             "filter_usage": self.filter_usage,
+            "wick_usage": self.wick_usage,
+            "auto_regulated_humidity": self.auto_regulated_humidity,
+            "water_shortage": self.water_shortage,
         }
 
     def __str__(self):

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -45,11 +45,13 @@ class DeviceAws(CallbacksMixin):
         uuid: str = None,
         name_api: str = None,
         mac: str = None,
+        type_name: str = None,
     ):
         self.api = api
         self.uuid = uuid
         self.name_api = name_api
         self.mac = mac
+        self.type_name = type_name
         _LOGGER.debug(f"creating blueair device aws: {self.uuid}")
 
     async def refresh(self):
@@ -128,6 +130,7 @@ class DeviceAws(CallbacksMixin):
         return {
             "uuid": self.uuid,
             "name": self.name,
+            "type_name": self.type_name,
             "name_api": self.name_api,
             "mac": self.mac,
             "firmware": self.firmware,

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -32,6 +32,8 @@ class DeviceAws(CallbacksMixin):
     humidity: int = None
     filter_usage: int = None  # percentage
     wifi_working: bool = None
+
+    # i35
     wick_usage: int = None  # percentage
     wick_dry_mode: bool = None
     wshortage: bool = None
@@ -115,6 +117,11 @@ class DeviceAws(CallbacksMixin):
     async def set_night_mode(self, night_mode: bool):
         self.night_mode = night_mode
         await self.api.set_device_info(self.uuid, "nightmode", "vb", night_mode)
+        self.publish_updates()
+
+    async def set_wick_dry_mode(self, value: bool):
+        self.wick_dry_mode = value
+        await self.api.set_device_info(self.uuid, "wickdrys", "vb", value)
         self.publish_updates()
 
     def __repr__(self):

--- a/src/blueair_api/util_bootstrap.py
+++ b/src/blueair_api/util_bootstrap.py
@@ -32,6 +32,7 @@ async def get_devices(
             uuid=device["uuid"],
             name=device["name"],
             mac=device["mac"],
+            type_name=device["type"],
         )
 
     devices = map(create_device, api_devices)


### PR DESCRIPTION
There are more, but I feel maybe we can update how these properties are created (e.g. using a Python descriptor or a helper method, or a metaclass) before typing more of them.

Also it seems like we could generate a device object entirely from the configuration json property. Some of the current attributes clearly do not apply to the humidifier -- and the humidifier attributes do not apply to the other device types.