### PR TITLE
refactor: use slots to fortify device classes.

### DIFF
--- a/src/blueair_api/callbacks.py
+++ b/src/blueair_api/callbacks.py
@@ -4,6 +4,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class CallbacksMixin:
+    __slots__ = ['_callbacks']
+
     def _setup_callbacks(self):
         self._callbacks = set()
 

--- a/src/blueair_api/device.py
+++ b/src/blueair_api/device.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 
 from .callbacks import CallbacksMixin
@@ -6,25 +7,27 @@ from .http_blueair import HttpBlueair
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass(init=False, slots=True)
 class Device(CallbacksMixin):
-    uuid: str = None
-    name: str = None
-    timezone: str = None
-    compatibility: str = None
-    model: str = None
-    mac: str = None
-    firmware: str = None
-    mcu_firmware: str = None
-    wlan_driver: str = None
-    room_location: str = None
+    api: HttpBlueair
+    uuid: str | None = None
+    name: str | None = None
+    timezone: str | None = None
+    compatibility: str | None = None
+    model: str | None = None
+    mac: str | None = None
+    firmware: str | None = None
+    mcu_firmware: str | None = None
+    wlan_driver: str | None = None
+    room_location: str | None = None
 
-    brightness: int = None
-    child_lock: bool = None
-    night_mode: bool = None
-    fan_speed: int = None
-    fan_mode: str = None
-    filter_expired: bool = None
-    wifi_working: bool = None
+    brightness: int | None = None
+    child_lock: bool | None = None
+    night_mode: bool | None = None
+    fan_speed: int | None = None
+    fan_mode: str | None = None
+    filter_expired: bool | None = None
+    wifi_working: bool | None = None
 
     def __init__(
         self,
@@ -73,27 +76,3 @@ class Device(CallbacksMixin):
 
     async def set_fan_speed(self, new_speed):
         await self.api.set_fan_speed(self.uuid, new_speed)
-
-    def __repr__(self):
-        return {
-            "uuid": self.uuid,
-            "name": self.name,
-            "timezone": self.timezone,
-            "compatibility": self.compatibility,
-            "model": self.model,
-            "mac": self.mac,
-            "firmware": self.firmware,
-            "mcu_firmware": self.mcu_firmware,
-            "wlan_driver": self.wlan_driver,
-            "room_location": self.room_location,
-            "brightness": self.brightness,
-            "child_lock": self.child_lock,
-            "night_mode": self.night_mode,
-            "fan_speed": self.fan_speed,
-            "filter_expired": self.filter_expired,
-            "fan_mode": self.fan_mode,
-            "wifi_working": self.wifi_working,
-        }
-
-    def __str__(self):
-        return f"{self.__repr__()}"

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 
 from .callbacks import CallbacksMixin
@@ -7,8 +8,9 @@ from .util import convert_api_array_to_dict, safely_get_json_value
 
 _LOGGER = logging.getLogger(__name__)
 
-
+@dataclasses.dataclass(init=False, slots=True)
 class DeviceAws(CallbacksMixin):
+    api: HttpAwsBlueair
     uuid: str = None
     name: str = None
     name_api: str = None
@@ -143,36 +145,3 @@ class DeviceAws(CallbacksMixin):
             return ModelEnum.MAX_311I
         return ModelEnum.UNKNOWN
 
-    def __repr__(self):
-        return {
-            "uuid": self.uuid,
-            "name": self.name,
-            "type_name": self.type_name,
-            "sku": self.sku,
-            "name_api": self.name_api,
-            "mac": self.mac,
-            "firmware": self.firmware,
-            "mcu_firmware": self.mcu_firmware,
-            "serial_number": self.serial_number,
-            "brightness": self.brightness,
-            "child_lock": self.child_lock,
-            "fan_speed": self.fan_speed,
-            "fan_auto_mode": self.fan_auto_mode,
-            "running": self.running,
-            "night_mode": self.night_mode,
-            "germ_shield": self.germ_shield,
-            "pm1": self.pm1,
-            "pm2_5": self.pm2_5,
-            "pm10": self.pm10,
-            "tVOC": self.tVOC,
-            "temperature": self.temperature,
-            "humidity": self.humidity,
-            "filter_usage": self.filter_usage,
-            "wick_usage": self.wick_usage,
-            "wick_dry_mode": self.wick_dry_mode,
-            "auto_regulated_humidity": self.auto_regulated_humidity,
-            "water_shortage": self.water_shortage,
-        }
-
-    def __str__(self):
-        return f"{self.__repr__()}"

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -136,7 +136,7 @@ class DeviceAws(CallbacksMixin):
     @property
     def model(self) -> ModelEnum:
         if self.sku == "111633":
-            return ModelEnum.HUMIDIFIER_I35
+            return ModelEnum.HUMIDIFIER_H35I
         if self.sku == "105826":
             return ModelEnum.PROTECT_7470I
         if self.sku == "110092":

--- a/src/blueair_api/model_enum.py
+++ b/src/blueair_api/model_enum.py
@@ -3,6 +3,6 @@ from enum import StrEnum
 
 class ModelEnum(StrEnum):
     UNKNOWN = "Unknown"
-    HUMIDIFIER_I35 = "Blueair Humidifier i35"
+    HUMIDIFIER_H35I = "Blueair Humidifier H35i"
     PROTECT_7470I = "Blueair Protect 7470i"
     MAX_311I = "311i Max"


### PR DESCRIPTION
I poked around defining properties explicitly, but realized it was a loosing game because we still have to maintain a local cache of the state (due to the slow async update from server). And the best way to represent the local cahced state is after our translation -- which means I will have to keep a private copy of all of the properties: `_running`, ... etc, which are still adhoc and defeated the purpose of adding the property accessors. 

Then I recalled Python support this thing calls 'slots' that forbids adding new members unless they are predeclared. That's exactly the semantics we would like to have. In modern times this feature is surfaced via the dataclasses classes. So I updated the classes to dataclasses. We also get repr and str for free this way.

I could only exercise the AWS code paths locally. I wish we had some kind of tests that can exercise both code paths that I can run  locally before filing a PR. 
