### PR TITLE
chore: update pytest workflow.

### DIFF
--- a/.github/workflows/pytestPR.yaml
+++ b/.github/workflows/pytestPR.yaml
@@ -15,14 +15,14 @@ jobs:
         python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v3
-      - name: developer mode install
-        run: pip install -e .
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install pytest dependencies
         run: pip install pytest pytest-md pytest-emoji
+      - name: developer mode install
+        run: pip install -e .
       - uses: pavelzw/pytest-action@v2
         with:
           emoji: false

--- a/.github/workflows/pytestPR.yaml
+++ b/.github/workflows/pytestPR.yaml
@@ -1,7 +1,10 @@
 name: "PyTest PR"
 
 on:
-  pull_request_target:
+  # Use pull_request, not pull_request_target because we run arbitrary code in
+  # this workflow. c.f.
+  # https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests
+  pull_request:
     types:
       - opened
       - edited

--- a/src/blueair_api/const.py
+++ b/src/blueair_api/const.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 SENSITIVE_FIELD_NAMES = [
     "username",


### PR DESCRIPTION
1. We shall run developer install after the python environment is set up.
2. Use on: pull_request instead the unsafe and broken on: pull_request_target. We are running arbitrary code and we do not need secretes like GITHUB_TOKEN. (I am not sure about why lintPR.yaml workflow requires it, but if it onlly lints then there is no arbitrary execution to exploit)
3. now that the workflow actually works, remove the dependency on typing_extension to fix the installation error.