### PR TITLE
fix: for devices missing expected api attributes

### DIFF
--- a/src/blueair_api/device.py
+++ b/src/blueair_api/device.py
@@ -15,19 +15,14 @@ class Device(CallbacksMixin):
     async def create_device(cls, api, uuid, name, mac, refresh=False):
         _LOGGER.debug("UUID:"+uuid)
         info = await api.get_info(uuid)
-        device = Device(
-            api=api,
-            uuid=uuid,
-            name=name,
-            mac=mac,
-            timezone=info["timezone"],
-            compatibility=info["compatibility"],
-            model=info["model"],
-            firmware=info["firmware"],
-            mcu_firmware=info["mcuFirmware"],
-            wlan_driver=info["wlanDriver"],
-            room_location=info["roomLocation"]
-        )
+        device_data = {
+            "api":api,
+            "uuid":uuid,
+            "name":name,
+            "mac":mac
+        }
+        device_data.update(info)
+        device = Device(**device_data)
         if refresh:
             await device.refresh()
         _LOGGER.debug(f"create_device blueair device: {device}")

--- a/src/blueair_api/device.py
+++ b/src/blueair_api/device.py
@@ -15,14 +15,19 @@ class Device(CallbacksMixin):
     async def create_device(cls, api, uuid, name, mac, refresh=False):
         _LOGGER.debug("UUID:"+uuid)
         info = await api.get_info(uuid)
-        device_data = {
-            "api":api,
-            "uuid":uuid,
-            "name":name,
-            "mac":mac
-        }
-        device_data.update(info)
-        device = Device(**device_data)
+        device = Device(
+            api=api,
+            uuid=uuid,
+            name=name,
+            mac=mac,
+            timezone=info.get("timezone", None),
+            compatibility=info.get("compatibility", None),
+            model=info.get("model",None),
+            firmware=info.get('firmware', None),
+            mcu_firmware=info.get("mcuFirmware",None),
+            wlan_driver=info.get("wlanDriver",None),
+            room_location=info["roomLocation"]
+        )
         if refresh:
             await device.refresh()
         _LOGGER.debug(f"create_device blueair device: {device}")

--- a/src/blueair_api/util.py
+++ b/src/blueair_api/util.py
@@ -62,6 +62,6 @@ def transform_data_points(data):
         "allpollu": "all_pollution",
     }
 
-    keys = [key_mapping[key] for key in data["sensors"]]
+    keys = [key_mapping[key] for key in data.get("sensors", {})]
 
-    return [dict(zip(keys, values)) for values in data["datapoints"]]
+    return [dict(zip(keys, values)) for values in data.get("datapoints", {})]


### PR DESCRIPTION
I have a strange bug where somehow a third-party device got added to my profile that has no datapoints, and no fields for `firmware`, `mcuFirmware`, etc. This updates the requests to make those requests optional so a keyerror isn't thrown for this device.