### PR TITLE
fix: use JWT username claim as userId path param

### DIFF
--- a/src/blueair_api/http_aws_blueair.py
+++ b/src/blueair_api/http_aws_blueair.py
@@ -164,6 +164,7 @@ class HttpAwsBlueair:
         self.access_token = response_json["access_token"]
         # Extract the username claim from the JWT to use as userId in API paths
         try:
+            assert self.access_token is not None
             payload = self.access_token.split(".")[1]
             # Add padding if needed
             payload += "=" * (4 - len(payload) % 4)

--- a/src/blueair_api/http_aws_blueair.py
+++ b/src/blueair_api/http_aws_blueair.py
@@ -1,4 +1,6 @@
 import functools
+import json
+import base64
 
 from logging import getLogger
 from typing import Any
@@ -24,6 +26,7 @@ def request_with_active_session(func):
             self.session_token = None
             self.session_secret = None
             self.access_token = None
+            self.user_id = None
             self.jwt = None
             response = await func(*args, **kwargs)
             return response
@@ -80,6 +83,7 @@ class HttpAwsBlueair:
         self.session_secret = None
 
         self.access_token = None
+        self.user_id = None
 
         self.jwt = None
 
@@ -158,6 +162,23 @@ class HttpAwsBlueair:
         )
         response_json = await response.json()
         self.access_token = response_json["access_token"]
+        # Extract the username claim from the JWT to use as userId in API paths
+        try:
+            payload = self.access_token.split(".")[1]
+            # Add padding if needed
+            payload += "=" * (4 - len(payload) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(payload))
+            self.user_id = claims.get("username", "")
+            _LOGGER.debug(f"Extracted user_id from JWT: {self.user_id}")
+        except Exception as e:
+            _LOGGER.warning(f"Failed to extract user_id from access_token JWT: {e}")
+            self.user_id = None
+
+    async def get_user_id(self) -> str:
+        if self.user_id is None:
+            await self.refresh_access_token()
+        assert self.user_id is not None
+        return self.user_id
 
     async def get_access_token(self) -> str:
         _LOGGER.debug("get_access_token")
@@ -183,7 +204,8 @@ class HttpAwsBlueair:
 
     @request_with_active_session
     async def device_sensors(self, device_name, device_uuid, duration: timedelta = timedelta(hours=10)):
-        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/{device_name}/r/telemetry/5m/historical"
+        user_id = await self.get_user_id()
+        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/{user_id}/r/telemetry/5m/historical"
         headers = {
             "Authorization": f"Bearer {await self.get_access_token()}",
         }
@@ -204,7 +226,8 @@ class HttpAwsBlueair:
     @request_with_active_session
     async def device_info(self, device_name, device_uuid) -> dict[str, Any]:
         _LOGGER.debug("device_info")
-        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/{device_name}/r/initial"
+        user_id = await self.get_user_id()
+        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/{user_id}/r/initial"
         headers = {
             "Authorization": f"Bearer {await self.get_access_token()}",
         }


### PR DESCRIPTION
### Problem

The `device_info` and `device_sensors` API calls were using `device_name` (the device's API name) as the path parameter in the URL (`/prod/c/{device_name}/r/...`). This works for single-device accounts, but **breaks for users with multiple devices** because the path parameter should identify the *user*, not the device.

### Root Cause

The AWS API endpoints expect the **user ID** (from the JWT `username` claim) in the URL path, not the device name. When `device_name` happened to match the user's ID (single-device accounts), requests succeeded. With multiple devices, each having a different `device_name`, the wrong value was being passed.

### Fix

- **Extract `user_id` from the JWT access token** after authentication by decoding the payload and reading the `username` claim
- **Store `user_id`** on the `HttpAwsBlueair` instance (initialized to `None`, populated on token refresh)
- **Replace `device_name` with `user_id`** in the URL path for both `device_info` and `device_sensors` endpoints
- Add `get_user_id()` helper that ensures the token has been fetched before returning the user ID
- Reset `user_id` on session refresh (in `request_with_active_session` decorator)

### Changed files

- **`src/blueair_api/http_aws_blueair.py`** — 25 insertions, 2 deletions

### Impact

All AWS-backed devices (Max, Protect, humidifiers, T10i, etc.) are affected. Users with multiple devices on the same account should now see data returned correctly for all of them, rather than only the first or none.