### PR TITLE
fix: join background thread on MQTT disconnect

### DIFF
--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -156,7 +156,10 @@ class MqttAwsBlueair:
         if self._client is not None:
             self._client.disconnect()
             self._connected = False
-            self._client = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+        self._client = None
 
     def _on_connect(self, client, userdata, flags, reason_code, properties):
         if reason_code == 0:


### PR DESCRIPTION
## Fix: Join background thread on MQTT disconnect

### Summary

Ensures the paho-mqtt `loop_forever` background thread is properly joined when `disconnect()` is called, preventing leaked threads.

### Problem

When `MqttAwsBlueair.disconnect()` was called, it disconnected the paho-mqtt client and set `self._client = None`, but never waited for the background thread running `loop_forever()` to actually exit. This could result in:

- Leaked daemon threads if `disconnect()` is called during integration unload
- Race conditions if `connect()` is called again before the old thread finishes

### Fix

`disconnect()` now calls `self._thread.join(timeout=5)` after disconnecting the client, waiting for the background thread to exit cleanly before clearing references. The 5-second timeout prevents blocking indefinitely if the thread is stuck.

### Changes

| File | Change |
|---|---|
| `mqtt_aws_blueair.py` | Add `thread.join(timeout=5)` in `disconnect()` |
