### PR TITLE
fix: MQTT reconnect with credential refresh on token expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Api Wrapper for BlueAir API using async in python, this was inspired by [this gu
 
 a lot of this is based on [hass-blueair](https://github.com/aijayadams/hass-blueair).
 
+## Features
+
+- **REST API** — async device discovery, sensor polling, and control commands (fan speed, brightness, child lock, etc.) for both legacy and AWS-based Blueair devices
+- **MQTT real-time updates** — receive sensor data (PM2.5, temperature, humidity, etc.) and device state changes via AWS IoT WebSocket with sub-second latency instead of 5-minute polling
+- **Automatic reconnect with credential refresh** — MQTT tokens expire after 24 hours; the client refreshes credentials and reconnects with exponential backoff (5s → 300s max) on unexpected disconnects
+- **Data-driven SKU mapping** — resolves 418+ device SKUs to human-readable product names (e.g., `111582` → "Blueair Blue Pure 511i Max") via a built-in lookup table
+- **Per-device hardware detection** — `mood_brightness_max` and `fan_speed_count` adapt automatically based on the device's hardware identifier
+
 ***
 
 [blueair_api]: https://github.com/dahlb/blueair_api

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -4,17 +4,22 @@ Connects to the Blueair cloud MQTT broker via WebSocket Secure (WSS)
 using credentials from the existing c/login API response. Provides
 real-time sensor data and device state change callbacks.
 
+On unexpected disconnect, refreshes credentials (tokens expire after
+24 hours) and reconnects with exponential backoff.
+
 MQTT broker endpoints and authentication flow determined through
 investigation of the Blueair cloud API responses and AWS IoT
 protocol behavior.
 """
+import asyncio
 import json
 import ssl
 import uuid
+import time
 import threading
 from logging import getLogger
 from typing import Any
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 
 import paho.mqtt.client as mqtt
 
@@ -26,6 +31,12 @@ _LOGGER = getLogger(__name__)
 SensorCallback = Callable[[str, dict[str, float]], None]
 StateCallback = Callable[[str, dict[str, Any]], None]
 EventCallback = Callable[[str, dict[str, Any]], None]
+CredentialRefresher = Callable[[], Awaitable[tuple[str, str, str]]]
+
+# Reconnect backoff parameters
+_RECONNECT_INITIAL_DELAY = 5
+_RECONNECT_MAX_DELAY = 300
+_RECONNECT_BACKOFF_FACTOR = 2
 
 
 class MqttAwsBlueair:
@@ -46,6 +57,17 @@ class MqttAwsBlueair:
         mqtt_client.connect()
         # ...
         mqtt_client.disconnect()
+
+    For automatic token refresh on reconnect, supply a credential_refresher:
+
+        async def refresh_creds():
+            await http_client.refresh_access_token()
+            return (
+                http_client.mqtt_auth_name,
+                http_client.mqtt_auth_signature,
+                http_client.mqtt_auth_token,
+            )
+        mqtt_client.credential_refresher = refresh_creds
     """
 
     def __init__(
@@ -71,9 +93,18 @@ class MqttAwsBlueair:
         self.on_disconnect_callback: Callable[[], None] | None = None
         self.on_connect_callback: Callable[[], None] | None = None
 
+        # Async callable that refreshes login and returns
+        # (mqtt_auth_name, mqtt_auth_signature, mqtt_auth_token).
+        self.credential_refresher: CredentialRefresher | None = None
+
+        # Event loop for running the async credential refresher from
+        # the synchronous paho disconnect callback thread.
+        self._event_loop = None
+
         self._client: mqtt.Client | None = None
         self._connected = False
-        self._thread: threading.Thread | None = None
+        self._stopping = False
+        self._reconnect_thread: threading.Thread | None = None
 
     @property
     def connected(self) -> bool:
@@ -100,25 +131,11 @@ class MqttAwsBlueair:
             self._client.subscribe(topic)
             _LOGGER.debug(f"Subscribed to {topic}")
 
-    def connect(self) -> None:
-        """Connect to the MQTT broker and start the message loop in a background thread."""
+    def _build_client(self) -> mqtt.Client:
+        """Create a new paho MQTT client with current credentials."""
         broker = AWS_MQTT_BROKERS.get(self._region)
         if broker is None:
             raise ValueError(f"No MQTT broker configured for region: {self._region}")
-
-        if not self._mqtt_auth_name or not self._mqtt_auth_signature or not self._mqtt_auth_token:
-            _LOGGER.error(
-                "MQTT auth credentials missing or empty "
-                f"(auth_name={bool(self._mqtt_auth_name)}, "
-                f"auth_signature={bool(self._mqtt_auth_signature)}, "
-                f"auth_token={bool(self._mqtt_auth_token)})"
-            )
-
-        _LOGGER.info(
-            f"Connecting to MQTT broker wss://{broker} "
-            f"(region={self._region}, client_id={self._client_id}, "
-            f"user_id={self._user_id}, devices={len(self._device_ids)})"
-        )
 
         client = mqtt.Client(
             callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
@@ -142,23 +159,55 @@ class MqttAwsBlueair:
                 "X-Amz-CustomAuthorizer-Token": self._mqtt_auth_token,
             },
         )
+        return client
 
-        self._client = client
-        client.connect(broker, 443, keepalive=60)
+    def connect(self, event_loop=None) -> None:
+        """Connect to the MQTT broker and start the network loop.
 
-        # Run the network loop in a daemon thread so it doesn't block
-        self._thread = threading.Thread(target=client.loop_forever, daemon=True)
-        self._thread.start()
+        Parameters
+        ----------
+        event_loop : asyncio event loop, optional
+            The running asyncio event loop. Required when
+            ``credential_refresher`` is set, so the reconnect thread
+            can schedule the async refresh on the correct loop.
+        """
+        self._event_loop = event_loop
+        self._stopping = False
+
+        broker = AWS_MQTT_BROKERS.get(self._region)
+        if broker is None:
+            raise ValueError(f"No MQTT broker configured for region: {self._region}")
+
+        if not self._mqtt_auth_name or not self._mqtt_auth_signature or not self._mqtt_auth_token:
+            _LOGGER.error(
+                "MQTT auth credentials missing or empty "
+                f"(auth_name={bool(self._mqtt_auth_name)}, "
+                f"auth_signature={bool(self._mqtt_auth_signature)}, "
+                f"auth_token={bool(self._mqtt_auth_token)})"
+            )
+
+        _LOGGER.info(
+            f"Connecting to MQTT broker wss://{broker} "
+            f"(region={self._region}, client_id={self._client_id}, "
+            f"user_id={self._user_id}, devices={len(self._device_ids)})"
+        )
+
+        self._client = self._build_client()
+        self._client.connect(broker, 443, keepalive=60)
+        # Use loop_start (non-blocking) so we can stop cleanly on reconnect.
+        self._client.loop_start()
 
     def disconnect(self) -> None:
         """Disconnect from the MQTT broker."""
         _LOGGER.info("Disconnecting from MQTT broker")
+        self._stopping = True
         if self._client is not None:
+            self._client.loop_stop()
             self._client.disconnect()
             self._connected = False
-        if self._thread is not None:
-            self._thread.join(timeout=5)
-            self._thread = None
+        if self._reconnect_thread is not None:
+            self._reconnect_thread.join(timeout=10)
+            self._reconnect_thread = None
         self._client = None
 
     def _on_connect(self, client, userdata, flags, reason_code, properties):
@@ -178,13 +227,94 @@ class MqttAwsBlueair:
             _LOGGER.error(f"MQTT connection failed: reason_code={reason_code}")
 
     def _on_disconnect(self, client, userdata, flags, reason_code, properties):
-        if reason_code == 0:
-            _LOGGER.info("MQTT disconnected cleanly")
-        else:
-            _LOGGER.warning(f"MQTT disconnected unexpectedly: reason_code={reason_code}")
         self._connected = False
+        if reason_code == 0 or self._stopping:
+            _LOGGER.info("MQTT disconnected cleanly")
+            if self.on_disconnect_callback:
+                self.on_disconnect_callback()
+            return
+
+        _LOGGER.warning(f"MQTT disconnected unexpectedly: reason_code={reason_code}")
         if self.on_disconnect_callback:
             self.on_disconnect_callback()
+
+        # Start reconnect with credential refresh in a background thread.
+        # We don't call loop_stop() here because we're on paho's network
+        # thread — it will exit naturally after this callback returns.
+        if self._reconnect_thread is None or not self._reconnect_thread.is_alive():
+            self._reconnect_thread = threading.Thread(
+                target=self._reconnect_loop, daemon=True
+            )
+            self._reconnect_thread.start()
+
+    def _reconnect_loop(self) -> None:
+        """Reconnect with exponential backoff, refreshing credentials each attempt."""
+        delay = _RECONNECT_INITIAL_DELAY
+        broker = AWS_MQTT_BROKERS.get(self._region)
+        if broker is None:
+            _LOGGER.error(f"No MQTT broker for region {self._region}; cannot reconnect")
+            return
+        attempt = 0
+
+        while not self._stopping:
+            attempt += 1
+            _LOGGER.info(f"MQTT reconnect attempt {attempt} in {delay}s...")
+            time.sleep(delay)
+            if self._stopping:
+                _LOGGER.info("MQTT reconnect cancelled (shutting down)")
+                return
+
+            # Paho's loop_start() may have auto-reconnected with stale
+            # credentials while we were sleeping. If so, tear it down
+            # and replace with a fresh-credential connection.
+            if self._connected:
+                _LOGGER.info(
+                    "MQTT auto-reconnected with existing credentials; "
+                    "replacing with fresh credentials"
+                )
+
+            # Clean up the old client. By now paho's network thread has
+            # exited (we slept long enough), so loop_stop() is safe.
+            if self._client is not None:
+                self._client.loop_stop()
+                self._client = None
+
+            # Refresh credentials if a refresher is available.
+            if self.credential_refresher and self._event_loop:
+                try:
+                    future = asyncio.run_coroutine_threadsafe(
+                        self.credential_refresher(), self._event_loop
+                    )
+                    new_name, new_sig, new_token = future.result(timeout=30)
+                    self._mqtt_auth_name = new_name
+                    self._mqtt_auth_signature = new_sig
+                    self._mqtt_auth_token = new_token
+                    _LOGGER.info("MQTT credentials refreshed successfully")
+                except Exception:
+                    _LOGGER.exception(
+                        f"Failed to refresh MQTT credentials (attempt {attempt}), "
+                        f"next retry in {min(delay * _RECONNECT_BACKOFF_FACTOR, _RECONNECT_MAX_DELAY)}s"
+                    )
+                    delay = min(delay * _RECONNECT_BACKOFF_FACTOR, _RECONNECT_MAX_DELAY)
+                    continue
+            elif not self.credential_refresher:
+                _LOGGER.warning(
+                    "No credential_refresher configured; reconnecting with existing tokens "
+                    "(may fail if tokens have expired)"
+                )
+
+            try:
+                self._client = self._build_client()
+                self._client.connect(broker, 443, keepalive=60)
+                self._client.loop_start()
+                _LOGGER.info(f"MQTT reconnected with fresh credentials (attempt {attempt})")
+                return
+            except Exception:
+                _LOGGER.exception(
+                    f"MQTT reconnect attempt {attempt} failed, "
+                    f"next retry in {min(delay * _RECONNECT_BACKOFF_FACTOR, _RECONNECT_MAX_DELAY)}s"
+                )
+                delay = min(delay * _RECONNECT_BACKOFF_FACTOR, _RECONNECT_MAX_DELAY)
 
     def _on_subscribe(self, client, userdata, mid, reason_codes, properties):
         _LOGGER.debug(f"MQTT subscription confirmed (mid={mid})")

--- a/tests/test_mqtt_aws_blueair.py
+++ b/tests/test_mqtt_aws_blueair.py
@@ -1,9 +1,13 @@
 """Tests for MqttAwsBlueair.
 
 Unit tests that mock the paho-mqtt client to verify message parsing,
-topic routing, callback dispatch, and device registration.
+topic routing, callback dispatch, device registration, and reconnection
+with credential refresh.
 """
+import asyncio
 import json
+import threading
+import time
 from unittest import TestCase, mock
 
 from blueair_api.mqtt_aws_blueair import MqttAwsBlueair
@@ -198,6 +202,147 @@ class TestDeviceRegistration(TestCase):
         client.register_device(FAKE_DEVICE_UUID)
         client.register_device(FAKE_DEVICE_UUID)
         assert client._device_ids.count(FAKE_DEVICE_UUID) == 1
+
+
+class TestDisconnectReconnect(TestCase):
+    """Tests for disconnect handling and reconnect with credential refresh."""
+
+    def test_clean_disconnect_no_reconnect(self):
+        """A clean disconnect (reason_code=0) should not trigger reconnect."""
+        client = make_mqtt_client()
+        client._stopping = False
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+
+        client._on_disconnect(mock_paho, None, None, 0, None)
+
+        assert client._connected is False
+        # No reconnect thread should be started
+        assert client._reconnect_thread is None
+
+    def test_stopping_disconnect_no_reconnect(self):
+        """When _stopping is True, no reconnect should happen."""
+        client = make_mqtt_client()
+        client._stopping = True
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+
+        client._on_disconnect(mock_paho, None, None, 7, None)
+
+        assert client._connected is False
+        assert client._reconnect_thread is None
+
+    def test_unexpected_disconnect_triggers_reconnect(self):
+        """An unexpected disconnect should start reconnect thread."""
+        client = make_mqtt_client()
+        client._stopping = False
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+
+        # Prevent the reconnect thread from actually running forever
+        with mock.patch.object(client, '_reconnect_loop'):
+            client._on_disconnect(mock_paho, None, None, 7, None)
+
+        assert client._connected is False
+        # loop_stop is NOT called here (we're on paho's thread);
+        # it happens in _reconnect_loop instead.
+        mock_paho.loop_stop.assert_not_called()
+        assert client._reconnect_thread is not None
+
+    def test_disconnect_callback_fires(self):
+        """on_disconnect_callback should fire on unexpected disconnect."""
+        client = make_mqtt_client()
+        client._stopping = False
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+        callback_fired = []
+        client.on_disconnect_callback = lambda: callback_fired.append(True)
+
+        with mock.patch.object(client, '_reconnect_loop'):
+            client._on_disconnect(mock_paho, None, None, 7, None)
+
+        assert len(callback_fired) == 1
+
+    @mock.patch('blueair_api.mqtt_aws_blueair.time.sleep')
+    def test_reconnect_loop_refreshes_credentials(self, mock_sleep):
+        """_reconnect_loop should call credential_refresher and reconnect."""
+        client = make_mqtt_client()
+        client._stopping = False
+
+        loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+        loop_thread.start()
+        client._event_loop = loop
+
+        async def fake_refresh():
+            return ("new-name", "new-sig", "new-token")
+
+        client.credential_refresher = fake_refresh
+
+        # Make _build_client return a mock, then stop the loop after one cycle
+        mock_paho = mock.MagicMock()
+        with mock.patch.object(client, '_build_client', return_value=mock_paho):
+            client._reconnect_loop()
+
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=5)
+        loop.close()
+
+        assert client._mqtt_auth_name == "new-name"
+        assert client._mqtt_auth_signature == "new-sig"
+        assert client._mqtt_auth_token == "new-token"
+        mock_paho.connect.assert_called_once()
+        mock_paho.loop_start.assert_called_once()
+
+    @mock.patch('blueair_api.mqtt_aws_blueair.time.sleep')
+    def test_reconnect_loop_retries_on_refresh_failure(self, mock_sleep):
+        """If credential refresh fails, it should retry with backoff."""
+        client = make_mqtt_client()
+        client._stopping = False
+
+        loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+        loop_thread.start()
+        client._event_loop = loop
+
+        call_count = 0
+
+        async def failing_then_ok_refresh():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("network error")
+            return ("new-name", "new-sig", "new-token")
+
+        client.credential_refresher = failing_then_ok_refresh
+
+        mock_paho = mock.MagicMock()
+        with mock.patch.object(client, '_build_client', return_value=mock_paho):
+            client._reconnect_loop()
+
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=5)
+        loop.close()
+
+        assert call_count == 2
+        # First call sleeps 5s, second call sleeps 10s (backoff)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(5)
+        mock_sleep.assert_any_call(10)
+
+    @mock.patch('blueair_api.mqtt_aws_blueair.time.sleep')
+    def test_reconnect_loop_stops_when_stopping(self, mock_sleep):
+        """_reconnect_loop should exit when _stopping is set."""
+        client = make_mqtt_client()
+
+        # Set stopping before sleep returns
+        def stop_on_sleep(delay):
+            client._stopping = True
+
+        mock_sleep.side_effect = stop_on_sleep
+
+        client._reconnect_loop()
+        # Should exit without error
 
     def test_register_device_while_connected_subscribes(self):
         """Registering a device while connected should subscribe immediately."""


### PR DESCRIPTION
Fixes dahlb/ha_blueair#328

## Problem

The MQTT client uses AWS IoT Custom Authorizer tokens that expire after 24 hours. When the connection drops (network blip, server-side disconnect, or token expiry), `loop_forever()` auto-reconnects with the **same stale WSS headers**, which fails silently. The connection stays down until HA is restarted.

Original MQTT check-in mentioned token refresh gap in original check-in: https://github.com/dahlb/ha_blueair/pull/325#issuecomment-4118347976.  This change addresses the gap.

Users see:
```
MQTT disconnected unexpectedly: reason_code=Unspecified error
```
…repeated 76+ times, with sensors stuck at 0.

## Root Cause

`MqttAwsBlueair` received auth tokens as static strings at construction time. Paho's built-in `loop_forever()` retry reuses the same client (and thus the same WSS headers), so expired tokens can never be replaced.

## Solution

Replace paho's built-in reconnect with a manual reconnect loop that refreshes credentials before each attempt:

1. **`loop_forever()` → `loop_start()`** — non-blocking network loop that can be cleanly stopped
2. **`credential_refresher` callback** — optional `async () → (name, signature, token)` callable that the consumer provides to fetch fresh tokens
3. **`_reconnect_loop()`** — on unexpected disconnect: stop the old client loop, refresh credentials via the async callback (scheduled on the HA event loop), build a new paho client with fresh WSS headers, and reconnect
4. **Exponential backoff** — 5s initial delay, 2× factor, 300s max
5. **`_stopping` flag** — prevents reconnect during intentional shutdown

The `connect()` method now accepts an optional `event_loop` parameter so the reconnect thread can call the async refresher via `run_coroutine_threadsafe()`.

## Changes

| File | Change |
|------|--------|
| `mqtt_aws_blueair.py` | Replaced `loop_forever` with `loop_start`; added `credential_refresher`, `_build_client()`, `_reconnect_loop()` with backoff; improved disconnect handling with `_stopping` flag |
| `test_mqtt_aws_blueair.py` | Added 7 reconnect tests: clean disconnect, stopping flag, unexpected disconnect triggers reconnect, credential refresh success/failure with backoff, shutdown during reconnect |
| `README.md` | Added features section documenting REST, MQTT, auto-reconnect, SKU mapping, and hardware detection |

## Reconnect Flow

```
on_disconnect(reason_code≠0)
  → spawn _reconnect_loop thread
      → sleep(delay)
      → loop_stop() old client (safe — paho thread has exited by now)
      → if already reconnected via paho auto-reconnect, log and continue
      → credential_refresher() → fresh tokens
      → _build_client() with new WSS headers
      → connect() + loop_start()
      → on_connect → re-subscribe all topics
```

Paho's `loop_start()` may auto-reconnect with existing credentials for transient blips (instant recovery). The reconnect loop then replaces the connection with fresh credentials to ensure long-term stability. If paho's reconnect fails (e.g., expired tokens), the loop handles it with fresh credentials.

On failure at any step, delay doubles (5→10→20→…→300s) and retries.

## Tests

27 unit tests, all passing. New tests cover:
- Clean disconnect → no reconnect
- `_stopping=True` → no reconnect
- Unexpected disconnect → reconnect thread started (no `loop_stop()` in callback)
- `_reconnect_loop` refreshes credentials and reconnects
- Credential refresh failure → retries with exponential backoff
- Shutdown during reconnect sleep → clean exit

Live-tested against a real Blueair purifier: socket-level disconnect simulating network drop → auto-reconnect in ~2s → credential refresh → fresh-credential reconnect → sensor data resumes.
- Credential refresh failure → retries with backoff
- Shutdown during reconnect sleep → clean exit

## Breaking Changes

`connect()` now accepts an optional `event_loop` keyword argument. Existing callers that don't pass it will still work — reconnect will proceed without credential refresh (with a warning log).
