### PR TITLE
fix: force full re-authentication in refresh_access_token to prevent stale JWT loop expiry refresh

### DIFF
--- a/src/blueair_api/http_aws_blueair.py
+++ b/src/blueair_api/http_aws_blueair.py
@@ -158,8 +158,15 @@ class HttpAwsBlueair:
 
     async def refresh_access_token(self) -> None:
         _LOGGER.debug("refresh_access_token")
-        if self.jwt is None:
-            await self.refresh_jwt()
+        # Always do a full re-authentication from scratch.
+        # The JWT from Gigya has a very short lifetime (~5 minutes) and cannot
+        # be reused.  Previously we skipped refresh_jwt() when self.jwt was
+        # still set, which caused MQTT credential refreshes to send an expired
+        # JWT and get stuck in a 401 loop.
+        self.session_token = None
+        self.session_secret = None
+        self.jwt = None
+        await self.refresh_jwt()
         url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/login"
         headers = {"idtoken": self.jwt, "authorization": f"Bearer {self.jwt}"}
         response: ClientResponse = (
@@ -173,6 +180,13 @@ class HttpAwsBlueair:
         self.mqtt_auth_name = response_json.get("ba_X-Amz-CustomAuthorizer-Name")
         self.mqtt_auth_signature = response_json.get("ba_X-Amz-CustomAuthorizer-Signature")
         self.mqtt_auth_token = response_json.get("ba_X-Amz-CustomAuthorizer-Token")
+        if self.mqtt_auth_name and self.mqtt_auth_signature and self.mqtt_auth_token:
+            _LOGGER.debug("refresh_access_token: obtained access token and MQTT credentials")
+        else:
+            _LOGGER.warning(
+                "refresh_access_token: MQTT credentials missing from login response; "
+                "MQTT real-time updates will not be available"
+            )
         # Extract the username claim from the JWT to use as userId in API paths
         try:
             assert self.access_token is not None

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -212,7 +212,7 @@ class MqttAwsBlueair:
 
     def _on_connect(self, client, userdata, flags, reason_code, properties):
         if reason_code == 0:
-            _LOGGER.info(f"MQTT connected successfully (devices={len(self._device_ids)})")
+            _LOGGER.debug(f"MQTT connected (devices={len(self._device_ids)})")
             self._connected = True
             # Subscribe to per-user event topic
             user_topic = f"c/{self._user_id}/s/event"
@@ -234,14 +234,14 @@ class MqttAwsBlueair:
                 self.on_disconnect_callback()
             return
 
-        _LOGGER.warning(f"MQTT disconnected unexpectedly: reason_code={reason_code}")
+        _LOGGER.debug(f"MQTT disconnected unexpectedly: reason_code={reason_code}")
         if self.on_disconnect_callback:
             self.on_disconnect_callback()
 
         # Start reconnect with credential refresh in a background thread.
         # We don't call loop_stop() here because we're on paho's network
         # thread — it will exit naturally after this callback returns.
-        _LOGGER.info("Starting MQTT reconnect loop with credential refresh")
+        _LOGGER.debug("Starting MQTT reconnect loop with credential refresh")
         if self._reconnect_thread is None or not self._reconnect_thread.is_alive():
             self._reconnect_thread = threading.Thread(
                 target=self._reconnect_loop, daemon=True
@@ -259,7 +259,7 @@ class MqttAwsBlueair:
 
         while not self._stopping:
             attempt += 1
-            _LOGGER.info(f"MQTT reconnect attempt {attempt} in {delay}s...")
+            _LOGGER.debug(f"MQTT reconnect attempt {attempt} in {delay}s...")
             time.sleep(delay)
             if self._stopping:
                 _LOGGER.info("MQTT reconnect cancelled (shutting down)")
@@ -269,7 +269,7 @@ class MqttAwsBlueair:
             # credentials while we were sleeping. If so, tear it down
             # and replace with a fresh-credential connection.
             if self._connected:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "MQTT auto-reconnected with existing credentials; "
                     "replacing with fresh credentials"
                 )
@@ -290,7 +290,7 @@ class MqttAwsBlueair:
                     self._mqtt_auth_name = new_name
                     self._mqtt_auth_signature = new_sig
                     self._mqtt_auth_token = new_token
-                    _LOGGER.info("MQTT credentials refreshed successfully")
+                    _LOGGER.debug("MQTT credentials refreshed successfully")
                 except Exception:
                     _LOGGER.exception(
                         f"Failed to refresh MQTT credentials (attempt {attempt}), "
@@ -308,7 +308,7 @@ class MqttAwsBlueair:
                 self._client = self._build_client()
                 self._client.connect(broker, 443, keepalive=60)
                 self._client.loop_start()
-                _LOGGER.info(f"MQTT reconnected with fresh credentials (attempt {attempt})")
+                _LOGGER.debug(f"MQTT reconnected with fresh credentials (attempt {attempt})")
                 return
             except Exception:
                 _LOGGER.exception(
@@ -402,7 +402,7 @@ class MqttAwsBlueair:
         # The event payload uses short field names: "o" for origin, "et" for event type.
         device_id = str(payload.get("o", payload.get("originDeviceId", "")))
         event_type = str(payload.get("et", payload.get("connectionEvent", "unknown")))
-        _LOGGER.info(f"Device event for {device_id}: {event_type} ({payload.get('m', '')})")
+        _LOGGER.debug(f"Device event for {device_id}: {event_type} ({payload.get('m', '')})")
         if self.on_event:
             try:
                 self.on_event(device_id, payload)

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -241,6 +241,7 @@ class MqttAwsBlueair:
         # Start reconnect with credential refresh in a background thread.
         # We don't call loop_stop() here because we're on paho's network
         # thread — it will exit naturally after this callback returns.
+        _LOGGER.info("Starting MQTT reconnect loop with credential refresh")
         if self._reconnect_thread is None or not self._reconnect_thread.is_alive():
             self._reconnect_thread = threading.Thread(
                 target=self._reconnect_loop, daemon=True


### PR DESCRIPTION
### Problem

Fixes #123 

After v1.50.1 introduced MQTT reconnect with credential refresh (#120), the reconnect loop gets stuck in an infinite 401 retry cycle when the AWS IoT broker disconnects (~hourly).

`refresh_access_token()` cached the authentication token and only refreshed it when `self.jwt is None`. But the JWT expires after ~5 minutes. When the MQTT reconnect loop called `refresh_access_token()` to get fresh MQTT credentials, the expired JWT was sent to the Blueair login endpoint, returning `401 Id Token Expired` every time. The `request_with_active_session` decorator (which clears `self.jwt` on error) only wraps REST API methods — not `refresh_access_token()` itself — so the MQTT path had no recovery.

REST polling was unaffected because it goes through `request_with_active_session`, which properly clears stale tokens and retries.

**Before (from a live HA instance):**
```
09:00:48 response status: 401
09:00:48 response json: {'error': 'Id Token Expired'}
09:00:48 Failed to refresh MQTT credentials (attempt 1), next retry in 10s
...
18:31:35 response status: 401
18:31:35 response json: {'error': 'Id Token Expired'}
18:31:35 Failed to refresh MQTT credentials (attempt 119), next retry in 300s
```

### Fix

`refresh_access_token()` now clears all cached auth state (`session_token`, `session_secret`, `jwt`) before calling `refresh_jwt()`, forcing a full 3-step re-authentication chain (session → JWT → access token) every time. This is safe because `refresh_access_token()` is only called during lazy init or explicit credential refresh — normal REST calls use the cached `get_access_token()` path.

Also downgrades routine MQTT reconnect log messages from INFO/WARNING to DEBUG. The AWS IoT broker disconnects roughly every hour as normal behavior — these shouldn't clutter the Home Assistant log.

### Verified: 24-hour soak test

Tested on a live Home Assistant instance over 24 hours. Every reconnect succeeds on the first attempt with fresh credentials:

```
2026-04-14 06:42  disconnect → credentials refreshed → reconnected ✓
2026-04-14 07:42  disconnect → credentials refreshed → reconnected ✓
2026-04-14 08:42  disconnect → credentials refreshed → reconnected ✓
2026-04-14 09:43  disconnect → credentials refreshed → reconnected ✓
2026-04-14 10:43  disconnect → credentials refreshed → reconnected ✓
2026-04-14 11:43  disconnect → credentials refreshed → reconnected ✓
2026-04-14 12:44  disconnect → credentials refreshed → reconnected ✓
2026-04-14 13:44  disconnect → credentials refreshed → reconnected ✓
2026-04-14 14:45  disconnect → credentials refreshed → reconnected ✓
2026-04-14 15:45  disconnect → credentials refreshed → reconnected ✓
2026-04-14 16:46  disconnect → credentials refreshed → reconnected ✓
2026-04-14 17:46  disconnect → credentials refreshed → reconnected ✓
2026-04-14 18:46  disconnect → credentials refreshed → reconnected ✓
2026-04-14 19:47  disconnect → credentials refreshed → reconnected ✓
2026-04-14 20:47  disconnect → credentials refreshed → reconnected ✓
2026-04-14 21:48  disconnect → credentials refreshed → reconnected ✓
2026-04-14 22:48  disconnect → credentials refreshed → reconnected ✓
2026-04-14 23:49  disconnect → credentials refreshed → reconnected ✓
2026-04-15 00:49  disconnect → credentials refreshed → reconnected ✓
2026-04-15 01:49  disconnect → credentials refreshed → reconnected ✓
2026-04-15 02:50  disconnect → credentials refreshed → reconnected ✓
2026-04-15 03:50  disconnect → credentials refreshed → reconnected ✓
2026-04-15 04:51  disconnect → credentials refreshed → reconnected ✓
```

Zero `Id Token Expired` errors. Every reconnect succeeds on attempt 1 within ~2 seconds.

### Changes

| File | Change |
|------|--------|
| `http_aws_blueair.py` | Clear cached session/JWT tokens in `refresh_access_token()` before re-authenticating; add diagnostic logging for MQTT credential presence |
| `mqtt_aws_blueair.py` | Downgrade routine disconnect/reconnect/credential-refresh log messages from INFO/WARNING to DEBUG; failures remain at WARNING/ERROR |