### PR TITLE
fix: use paho native reconnect with on_pre_connect token refresh

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -256,6 +256,69 @@ A custom reconnect thread outside paho's event loop has these problems:
 
 Using paho's native hooks avoids all of these issues.
 
+## Sensor Data Stream TTL
+
+Blueair devices do not publish 5-second sensor data (`d/<id>/s/5s`)
+indefinitely. Each device declares a TTL in its configuration
+(`configuration.ds.rt5s.ttl`), typically 1200 seconds (20 minutes).
+After the TTL expires, the device stops publishing to the topic even
+though the MQTT subscription remains active on the broker.
+
+The TTL resets when a new subscription is made to the topic. This is
+by design — the mobile app only subscribes while the user is actively
+viewing sensor data, so short sessions never hit the TTL.
+
+For always-on consumers (e.g. Home Assistant), the client must
+periodically re-subscribe to keep the data stream alive.
+
+### How It Works
+
+1. **Periodic re-subscribe timer** — On connect, a daemon timer starts
+   at 75% of the TTL interval (default: 900s for 1200s TTL). When it
+   fires, the client unsubscribes then subscribes to `d/<id>/s/5s` for
+   every registered device. This resets the device-side TTL countdown.
+
+2. **Connected event re-subscribe** — When a device sends a `Connected`
+   event (device came online), the client immediately re-subscribes to
+   that device's sensor topic. This ensures data starts flowing as soon
+   as the device is available.
+
+3. **Dynamic TTL** — Call `set_sensor_ttl(seconds)` with the value from
+   the device configuration (`configuration.ds.rt5s.ttl`). If not set,
+   the default of 1200 seconds is used. Values ≤ 0 are ignored (the
+   stream never expires).
+
+### Data Streams by TTL
+
+| Stream | Topic Pattern | TTL | Publish Interval | Purpose |
+|--------|---------------|-----|------------------|---------|
+| `rt1s` | `d/<id>/s/1s` | 0 | 1 second | Real-time display, no retention |
+| `rt5s` | `d/<id>/s/5s` | 1200 | 5 seconds | Live monitoring (our primary source) |
+| `rt5m` | `d/<id>/s/5m` | 1200 | 5 minutes | Short-term charts |
+| `b5m` | `$aws/rules/.../batch/b5m` | -1 | 5 minutes | Historical data (always publishing) |
+| `rssi` | `d/<id>/s/rssi` | 600 | 60 seconds | Wi-Fi signal strength |
+| State topics | `d/<id>/s/<name>` | -1 | On change | Fan speed, standby, etc. (never expire) |
+
+The `b5m` stream feeds the cloud database for historical charts via the
+REST API. It never stops (`ttl: -1`), runs independently of subscribers,
+and routes through an AWS IoT Rules Engine ingest topic.
+
+### Usage
+
+```python
+mqtt = MqttAwsBlueair(...)
+
+# Set TTL from device config (optional — defaults to 1200s)
+mqtt.set_sensor_ttl(1200)
+
+# Register devices and connect as usual
+mqtt.register_device(device_uuid)
+mqtt.connect()
+```
+
+The re-subscribe timer starts automatically on connect and cancels on
+disconnect. No additional setup is required.
+
 ## Graceful Degradation
 
 If MQTT credentials are not present in the login response (older API
@@ -276,3 +339,5 @@ library falls back to REST-only polling. MQTT is an optional enhancement.
   `reconnect_delay_set()` (backoff configuration)
 - Subscriptions are placed in `on_connect` so they survive reconnects
   (recommended pattern from paho's own documentation)
+- Sensor data streams have a device-side TTL (typically 1200s) — the
+  client automatically re-subscribes to keep them alive

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -276,8 +276,11 @@ periodically re-subscribe to keep the data stream alive.
 
 1. **Periodic re-subscribe timer** — On connect, a daemon timer starts
    at 75% of the TTL interval (default: 900s for 1200s TTL). When it
-   fires, the client unsubscribes then subscribes to `d/<id>/s/5s` for
-   every registered device. This resets the device-side TTL countdown.
+   fires, the client subscribes to `d/<id>/s/5s` for every registered
+   device. Per MQTT spec, subscribing to an already-subscribed topic is
+   idempotent (broker sends SUBACK), so this is safe.  We intentionally
+   do NOT unsubscribe first — unsubscribing kills the device's data
+   push and the immediate re-subscribe doesn't always restart it.
 
 2. **Connected event re-subscribe** — When a device sends a `Connected`
    event (device came online), the client immediately re-subscribes to

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -22,7 +22,7 @@ alongside the REST API tokens. No additional API calls are needed.
 The login response includes these fields used for MQTT:
 
 | Login Response Field | Purpose |
-|---|---|
+| --- | --- |
 | `access_token` | JWT containing `username` claim used in topic paths |
 | `ba_X-Amz-CustomAuthorizer-Name` | AWS IoT Custom Authorizer name |
 | `ba_X-Amz-CustomAuthorizer-Signature` | AWS IoT Custom Authorizer signature |
@@ -36,7 +36,7 @@ Tokens expire after 24 hours (`expires_in: 86400`).
 Each region has a dedicated AWS IoT Core endpoint:
 
 | Region | Broker Host |
-|--------|-------------|
+| -------- | ------------- |
 | `us` | `a3tpdpjvxk6yog-ats.iot.us-east-2.amazonaws.com` |
 | `eu` | `a3tpdpjvxk6yog-ats.iot.eu-west-1.amazonaws.com` |
 | `au` | `a3tpdpjvxk6yog-ats.iot.eu-west-1.amazonaws.com` |
@@ -66,6 +66,7 @@ Published by the device every 5 seconds. Payload is a SenML JSON array:
 ```
 
 Each object has:
+
 - `n`: sensor name
 - `v`: numeric value
 
@@ -115,7 +116,7 @@ One subscription covers all devices for the user.
 ```
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `et` | Event type: `"Connected"` or `"NotConnected"` |
 | `o` | Origin device UUID |
 | `m` | Human-readable message |
@@ -127,7 +128,7 @@ One subscription covers all devices for the user.
 ### Observed Timing
 
 | Transition | Latency |
-|---|---|
+| --- | --- |
 | Device powered off → `NotConnected` event | ~3 minutes |
 | Device powered on → `Connected` event | ~34 seconds |
 | `Connected` → first sensor data | ~5 seconds |
@@ -162,7 +163,7 @@ mqtt.disconnect()
 ### Callbacks
 
 | Callback | Arguments | Trigger |
-|----------|-----------|---------|
+| ---------- | ----------- | --------- |
 | `on_sensor_data` | `(device_id: str, sensors: dict[str, float])` | Every ~5s per device |
 | `on_state_change` | `(device_id: str, state: dict[str, Any])` | On device state change |
 | `on_event` | `(device_id: str, event: dict[str, Any])` | On connect/disconnect |
@@ -211,7 +212,7 @@ inside paho's reconnect flow:
 When a connection is lost, paho's `loop_forever()` (running in the
 `loop_start()` thread) executes this sequence:
 
-```
+```text
 connection lost
   → _do_on_disconnect() fires on_disconnect callback
   → _reconnect_wait() sleeps with exponential backoff (5s → 10s → ... → 300s)
@@ -232,7 +233,7 @@ race conditions.
 ### Failure Scenarios
 
 | Scenario | Behavior |
-|---|---|
+| --- | --- |
 | Token expires, AWS closes connection | Paho detects loss → waits 5s → `on_pre_connect` refreshes → reconnects with new tokens |
 | Token refresh fails (e.g., network down) | `on_pre_connect` catches exception, logs it → paho tries with stale tokens → WS handshake fails → paho backs off → retries (calls `on_pre_connect` again) |
 | AWS broker unreachable | Paho retries with exponential backoff up to 300s → keeps trying indefinitely |
@@ -291,7 +292,7 @@ periodically re-subscribe to keep the data stream alive.
 ### Data Streams by TTL
 
 | Stream | Topic Pattern | TTL | Publish Interval | Purpose |
-|--------|---------------|-----|------------------|---------|
+| -------- | --------------- | ----- | ------------------ | --------- |
 | `rt1s` | `d/<id>/s/1s` | 0 | 1 second | Real-time display, no retention |
 | `rt5s` | `d/<id>/s/5s` | 1200 | 5 seconds | Live monitoring (our primary source) |
 | `rt5m` | `d/<id>/s/5m` | 1200 | 5 minutes | Short-term charts |
@@ -303,7 +304,7 @@ The `b5m` stream feeds the cloud database for historical charts via the
 REST API. It never stops (`ttl: -1`), runs independently of subscribers,
 and routes through an AWS IoT Rules Engine ingest topic.
 
-### Usage
+### TTL Usage Example
 
 ```python
 mqtt = MqttAwsBlueair(...)

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -169,6 +169,93 @@ mqtt.disconnect()
 | `on_connect_callback` | `()` | MQTT connection established |
 | `on_disconnect_callback` | `()` | MQTT connection lost |
 
+## Reconnection & Token Refresh
+
+AWS IoT Custom Authorizer tokens expire after 24 hours. When a token
+expires (or the connection drops for any reason), the MQTT broker closes
+the WebSocket connection. The client must obtain fresh tokens and
+reconnect.
+
+### Architecture Decision: Use Paho's Native Reconnect
+
+**Do NOT disable paho's built-in reconnect** (`_reconnect_on_failure`).
+An earlier implementation set `_reconnect_on_failure = False` and used a
+custom reconnect thread. This caused **silent connection death**: when the
+connection dropped, paho's `loop_forever()` thread exited immediately
+(because `not self._reconnect_on_failure → run = False`), and since it
+runs as a daemon thread, nothing in the system noticed. The custom
+reconnect thread relied on `on_disconnect` firing to spawn it, but that
+callback runs on the same dying paho thread and could race with the exit.
+
+### How Token Refresh Works
+
+The implementation uses two paho-native hooks that run synchronously
+inside paho's reconnect flow:
+
+1. **`on_pre_connect` callback** — Called by paho immediately before each
+   `reconnect()` creates a new socket. We use this to call the async
+   `credential_refresher` (which calls `refresh_access_token()` on the
+   HTTP client) and update the stored auth credentials.
+
+2. **`ws_set_options(headers=callable)`** — Instead of passing a static
+   dict of WebSocket headers, we pass a callable that returns the
+   *current* credentials on every WebSocket handshake. Paho calls this
+   during `_WebsocketWrapper._do_handshake()` on every connection
+   (including reconnects).
+
+3. **`reconnect_delay_set(min_delay=5, max_delay=300)`** — Configures
+   paho's built-in exponential backoff for reconnection attempts.
+
+### Reconnect Flow (Paho Internal)
+
+When a connection is lost, paho's `loop_forever()` (running in the
+`loop_start()` thread) executes this sequence:
+
+```
+connection lost
+  → _do_on_disconnect() fires on_disconnect callback
+  → _reconnect_wait() sleeps with exponential backoff (5s → 10s → ... → 300s)
+  → reconnect()
+      → on_pre_connect() ← refreshes credentials here
+      → _create_socket()
+          → _WebsocketWrapper._do_handshake(extra_headers)
+              → callable headers returns fresh tokens ← applied here
+      → _send_connect() sends MQTT CONNECT packet
+  → on_connect() fires
+      → re-subscribes to all device topics
+  → backoff timer resets to min_delay on successful CONNACK
+```
+
+This is all handled by a single paho thread — no custom threads, no
+race conditions.
+
+### Failure Scenarios
+
+| Scenario | Behavior |
+|---|---|
+| Token expires, AWS closes connection | Paho detects loss → waits 5s → `on_pre_connect` refreshes → reconnects with new tokens |
+| Token refresh fails (e.g., network down) | `on_pre_connect` catches exception, logs it → paho tries with stale tokens → WS handshake fails → paho backs off → retries (calls `on_pre_connect` again) |
+| AWS broker unreachable | Paho retries with exponential backoff up to 300s → keeps trying indefinitely |
+| Clean disconnect (`disconnect()` called) | Paho stops the loop — no reconnect attempted |
+
+### Why Not a Custom Reconnect Thread?
+
+A custom reconnect thread outside paho's event loop has these problems:
+
+- **Race condition**: Paho's own reconnect (if enabled) races with the
+  custom thread, both trying to connect simultaneously.
+- **Silent death**: If paho's reconnect is disabled to avoid the race,
+  the `loop_forever()` thread exits silently on disconnect (daemon thread,
+  no exception, no log). The custom thread must be spawned from
+  `on_disconnect`, which runs on the dying thread.
+- **Client rebuild**: The custom thread typically rebuilds the entire
+  paho Client, losing all internal state (subscriptions, message queues,
+  mid tracking).
+- **No CONNACK verification**: `connect()` is non-blocking; the custom
+  thread must poll for connection success separately.
+
+Using paho's native hooks avoids all of these issues.
+
 ## Graceful Degradation
 
 If MQTT credentials are not present in the login response (older API
@@ -182,3 +269,10 @@ library falls back to REST-only polling. MQTT is an optional enhancement.
 - AWS IoT Core supports millions of concurrent connections; one subscriber
   per user account is negligible
 - `paho-mqtt` (>= 2.0) is used for the MQTT client implementation
+- **Never set `_reconnect_on_failure = False`** — see "Reconnection &
+  Token Refresh" section above for why
+- Key paho hooks used: `on_pre_connect` (credential refresh),
+  `ws_set_options(headers=callable)` (dynamic WS headers),
+  `reconnect_delay_set()` (backoff configuration)
+- Subscriptions are placed in `on_connect` so they survive reconnects
+  (recommended pattern from paho's own documentation)

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import ssl
 import uuid
+import threading
 from logging import getLogger
 from typing import Any
 from collections.abc import Callable, Awaitable
@@ -33,6 +34,14 @@ SensorCallback = Callable[[str, dict[str, float]], None]
 StateCallback = Callable[[str, dict[str, Any]], None]
 EventCallback = Callable[[str, dict[str, Any]], None]
 CredentialRefresher = Callable[[], Awaitable[tuple[str, str, str]]]
+
+# Default sensor stream TTL in seconds.  Devices declare their own TTL
+# in configuration.ds.rt5s.ttl; this fallback is used when no TTL is
+# provided.  Most Blueair devices use 1200 (20 minutes).
+_DEFAULT_SENSOR_TTL = 1200
+
+# Re-subscribe at 75 % of the TTL to avoid data gaps.
+_TTL_RESUBSCRIBE_RATIO = 0.75
 
 
 class MqttAwsBlueair:
@@ -100,6 +109,8 @@ class MqttAwsBlueair:
         self._client: mqtt.Client | None = None
         self._connected = False
         self._stopping = False
+        self._sensor_ttl: int = _DEFAULT_SENSOR_TTL
+        self._resubscribe_timer: threading.Timer | None = None
 
     @property
     def connected(self) -> bool:
@@ -125,6 +136,69 @@ class MqttAwsBlueair:
         for topic in topics:
             self._client.subscribe(topic)
             _LOGGER.debug(f"Subscribed to {topic}")
+
+    def set_sensor_ttl(self, ttl_seconds: int) -> None:
+        """Set the sensor data stream TTL from the device configuration.
+
+        The TTL comes from ``configuration.ds.rt5s.ttl`` in the device
+        info API response.  When set, the client will periodically
+        re-subscribe to sensor topics at 75% of this interval to keep
+        the device publishing real-time data.
+
+        Parameters
+        ----------
+        ttl_seconds : int
+            TTL in seconds from the device config.  Values <= 0 are
+            ignored (stream never expires).
+        """
+        if ttl_seconds > 0:
+            self._sensor_ttl = ttl_seconds
+            _LOGGER.debug(f"Sensor TTL set to {ttl_seconds}s (re-subscribe every {int(ttl_seconds * _TTL_RESUBSCRIBE_RATIO)}s)")
+
+    def _resubscribe_sensor_topics(self) -> None:
+        """Unsubscribe and re-subscribe to sensor topics for all devices.
+
+        This resets the device-side TTL countdown, keeping the 5-second
+        sensor data stream alive.  Matches the Blueair app's
+        ``MqttService.resubscribeRt5s()`` pattern: unsubscribe first,
+        then subscribe.
+        """
+        if self._client is None or not self._connected:
+            return
+        for device_uuid in self._device_ids:
+            topic = f"d/{device_uuid}/s/5s"
+            try:
+                self._client.unsubscribe(topic)
+                self._client.subscribe(topic)
+                _LOGGER.debug(f"Re-subscribed to {topic} (TTL keepalive)")
+            except Exception:
+                _LOGGER.exception(f"Failed to re-subscribe to {topic}")
+
+    def _start_resubscribe_timer(self) -> None:
+        """Start the periodic re-subscribe timer based on the sensor TTL."""
+        self._cancel_resubscribe_timer()
+        if self._sensor_ttl <= 0 or self._stopping:
+            return
+        interval = int(self._sensor_ttl * _TTL_RESUBSCRIBE_RATIO)
+        _LOGGER.debug(f"Starting sensor re-subscribe timer (every {interval}s, TTL={self._sensor_ttl}s)")
+        self._resubscribe_timer = threading.Timer(interval, self._resubscribe_timer_fired)
+        self._resubscribe_timer.daemon = True
+        self._resubscribe_timer.start()
+
+    def _cancel_resubscribe_timer(self) -> None:
+        """Cancel the periodic re-subscribe timer if running."""
+        if self._resubscribe_timer is not None:
+            self._resubscribe_timer.cancel()
+            self._resubscribe_timer = None
+
+    def _resubscribe_timer_fired(self) -> None:
+        """Called when the re-subscribe timer fires."""
+        if self._stopping or not self._connected:
+            return
+        _LOGGER.info(f"Sensor TTL keepalive: re-subscribing to sensor topics for {len(self._device_ids)} device(s)")
+        self._resubscribe_sensor_topics()
+        # Restart the timer for the next cycle
+        self._start_resubscribe_timer()
 
     def _build_client(self) -> mqtt.Client:
         """Create a new paho MQTT client with current credentials."""
@@ -241,6 +315,7 @@ class MqttAwsBlueair:
         """Disconnect from the MQTT broker."""
         _LOGGER.info("Disconnecting from MQTT broker")
         self._stopping = True
+        self._cancel_resubscribe_timer()
         if self._client is not None:
             self._client.loop_stop()
             self._client.disconnect()
@@ -258,6 +333,9 @@ class MqttAwsBlueair:
             # Subscribe to all registered devices
             for device_uuid in self._device_ids:
                 self._subscribe_device(device_uuid)
+            # Start the periodic re-subscribe timer to keep sensor
+            # data streams alive (resets the device-side TTL).
+            self._start_resubscribe_timer()
             if self.on_connect_callback:
                 self.on_connect_callback()
         else:
@@ -265,6 +343,7 @@ class MqttAwsBlueair:
 
     def _on_disconnect(self, client, userdata, flags, reason_code, properties):
         self._connected = False
+        self._cancel_resubscribe_timer()
         if reason_code == 0 or self._stopping:
             _LOGGER.info("MQTT disconnected cleanly")
         else:
@@ -367,6 +446,19 @@ class MqttAwsBlueair:
         device_id = str(payload.get("o", payload.get("originDeviceId", "")))
         event_type = str(payload.get("et", payload.get("connectionEvent", "unknown")))
         _LOGGER.debug(f"Device event for {device_id}: {event_type} ({payload.get('m', '')})")
+
+        # When a device comes online, re-subscribe to its sensor topic
+        # to reset the TTL and start receiving 5s data.  This matches
+        # the Blueair app's SimpleMqttCallBack behavior.
+        if event_type == "Connected" and device_id and self._client is not None:
+            topic = f"d/{device_id}/s/5s"
+            try:
+                self._client.unsubscribe(topic)
+                self._client.subscribe(topic)
+                _LOGGER.info(f"Re-subscribed to {topic} (device Connected event)")
+            except Exception:
+                _LOGGER.exception(f"Failed to re-subscribe on Connected event for {device_id}")
+
         if self.on_event:
             try:
                 self.on_event(device_id, payload)

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -200,7 +200,7 @@ class MqttAwsBlueair:
         """Called when the re-subscribe timer fires."""
         if self._stopping or not self._connected:
             return
-        _LOGGER.info(f"Sensor TTL keepalive: re-subscribing to sensor topics for {len(self._device_ids)} device(s)")
+        _LOGGER.debug(f"Sensor TTL keepalive: re-subscribing to sensor topics for {len(self._device_ids)} device(s)")
         self._resubscribe_sensor_topics()
         # Restart the timer for the next cycle
         self._start_resubscribe_timer()
@@ -455,7 +455,7 @@ class MqttAwsBlueair:
         # When a device comes online, re-subscribe to its sensor topic
         # to reset the TTL and start receiving 5s data.
         client = self._client  # snapshot to avoid race with disconnect()
-        if event_type == "Connected" and device_id and client is not None:
+        if event_type == "Connected" and device_id in self._device_ids and client is not None:
             topic = f"d/{device_id}/s/5s"
             try:
                 client.subscribe(topic)

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -162,14 +162,18 @@ class MqttAwsBlueair:
         sensor data stream alive.  Matches the Blueair app's
         ``MqttService.resubscribeRt5s()`` pattern: unsubscribe first,
         then subscribe.
+
+        Safe to call from any thread — guards against client being
+        None or disconnected (e.g. during shutdown race).
         """
-        if self._client is None or not self._connected:
+        client = self._client  # snapshot to avoid race with disconnect()
+        if client is None or not self._connected:
             return
         for device_uuid in self._device_ids:
             topic = f"d/{device_uuid}/s/5s"
             try:
-                self._client.unsubscribe(topic)
-                self._client.subscribe(topic)
+                client.unsubscribe(topic)
+                client.subscribe(topic)
                 _LOGGER.debug(f"Re-subscribed to {topic} (TTL keepalive)")
             except Exception:
                 _LOGGER.exception(f"Failed to re-subscribe to {topic}")
@@ -450,11 +454,12 @@ class MqttAwsBlueair:
         # When a device comes online, re-subscribe to its sensor topic
         # to reset the TTL and start receiving 5s data.  This matches
         # the Blueair app's SimpleMqttCallBack behavior.
-        if event_type == "Connected" and device_id and self._client is not None:
+        client = self._client  # snapshot to avoid race with disconnect()
+        if event_type == "Connected" and device_id and client is not None:
             topic = f"d/{device_id}/s/5s"
             try:
-                self._client.unsubscribe(topic)
-                self._client.subscribe(topic)
+                client.unsubscribe(topic)
+                client.subscribe(topic)
                 _LOGGER.info(f"Re-subscribed to {topic} (device Connected event)")
             except Exception:
                 _LOGGER.exception(f"Failed to re-subscribe on Connected event for {device_id}")

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -4,8 +4,11 @@ Connects to the Blueair cloud MQTT broker via WebSocket Secure (WSS)
 using credentials from the existing c/login API response. Provides
 real-time sensor data and device state change callbacks.
 
-On unexpected disconnect, refreshes credentials (tokens expire after
-24 hours) and reconnects with exponential backoff.
+On unexpected disconnect, paho's built-in reconnect loop handles
+reconnection with exponential backoff.  Before each reconnect attempt
+the ``on_pre_connect`` hook refreshes credentials (tokens expire after
+24 hours), and the ``ws_set_options(headers=callable)`` mechanism
+ensures the new tokens are applied to the WebSocket handshake.
 
 MQTT broker endpoints and authentication flow determined through
 investigation of the Blueair cloud API responses and AWS IoT
@@ -15,8 +18,6 @@ import asyncio
 import json
 import ssl
 import uuid
-import time
-import threading
 from logging import getLogger
 from typing import Any
 from collections.abc import Callable, Awaitable
@@ -32,11 +33,6 @@ SensorCallback = Callable[[str, dict[str, float]], None]
 StateCallback = Callable[[str, dict[str, Any]], None]
 EventCallback = Callable[[str, dict[str, Any]], None]
 CredentialRefresher = Callable[[], Awaitable[tuple[str, str, str]]]
-
-# Reconnect backoff parameters
-_RECONNECT_INITIAL_DELAY = 5
-_RECONNECT_MAX_DELAY = 300
-_RECONNECT_BACKOFF_FACTOR = 2
 
 
 class MqttAwsBlueair:
@@ -98,13 +94,12 @@ class MqttAwsBlueair:
         self.credential_refresher: CredentialRefresher | None = None
 
         # Event loop for running the async credential refresher from
-        # the synchronous paho disconnect callback thread.
+        # the synchronous paho callback thread.
         self._event_loop = None
 
         self._client: mqtt.Client | None = None
         self._connected = False
         self._stopping = False
-        self._reconnect_thread: threading.Thread | None = None
 
     @property
     def connected(self) -> bool:
@@ -142,24 +137,69 @@ class MqttAwsBlueair:
             client_id=self._client_id,
             transport="websockets",
         )
+        # Let paho handle reconnection natively.  We refresh credentials
+        # in on_pre_connect and supply a headers callable so each new
+        # WebSocket handshake picks up the latest tokens automatically.
+        client.reconnect_delay_set(min_delay=5, max_delay=300)
         client.on_connect = self._on_connect
+        client.on_connect_fail = self._on_connect_fail
         client.on_message = self._on_message
         client.on_disconnect = self._on_disconnect
         client.on_subscribe = self._on_subscribe
+        client.on_pre_connect = self._on_pre_connect
+
+        # Route paho's internal logging (PINGREQ/PINGRESP, reconnect
+        # attempts, CONNACK details) through Python's standard logging.
+        # Visible in HA when debug logging is enabled for paho.mqtt.client.
+        client.enable_logger(_LOGGER)
 
         # TLS for WSS
         client.tls_set(cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLS_CLIENT)
 
-        # AWS IoT Custom Authorizer headers
+        # AWS IoT Custom Authorizer headers — use a callable so that
+        # paho calls it on every (re)connect to get fresh tokens.
         client.ws_set_options(
             path="/mqtt",
-            headers={
-                "X-Amz-CustomAuthorizer-Name": self._mqtt_auth_name,
-                "X-Amz-CustomAuthorizer-Signature": self._mqtt_auth_signature,
-                "X-Amz-CustomAuthorizer-Token": self._mqtt_auth_token,
-            },
+            headers=self._get_ws_headers,
         )
         return client
+
+    def _get_ws_headers(self, default_headers: dict[str, str]) -> dict[str, str]:
+        """Return WebSocket headers with the current auth credentials.
+
+        Called by paho on every WebSocket handshake (including reconnects).
+        """
+        default_headers["X-Amz-CustomAuthorizer-Name"] = self._mqtt_auth_name
+        default_headers["X-Amz-CustomAuthorizer-Signature"] = self._mqtt_auth_signature
+        default_headers["X-Amz-CustomAuthorizer-Token"] = self._mqtt_auth_token
+        return default_headers
+
+    def _on_pre_connect(self, client, userdata) -> None:
+        """Refresh credentials before each connection/reconnection attempt.
+
+        Paho calls this synchronously immediately before ``reconnect()``
+        creates a new socket.  We bridge into the async event loop to
+        call the credential refresher so that ``_get_ws_headers`` will
+        return fresh tokens for the upcoming WebSocket handshake.
+        """
+        _LOGGER.info("MQTT pre-connect: preparing for connection attempt")
+        if not self.credential_refresher or not self._event_loop:
+            _LOGGER.debug("MQTT pre-connect: no credential_refresher configured, using existing tokens")
+            return
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                self.credential_refresher(), self._event_loop
+            )
+            new_name, new_sig, new_token = future.result(timeout=30)
+            self._mqtt_auth_name = new_name
+            self._mqtt_auth_signature = new_sig
+            self._mqtt_auth_token = new_token
+            _LOGGER.info("MQTT credentials refreshed successfully via on_pre_connect")
+        except Exception:
+            _LOGGER.exception(
+                "Failed to refresh MQTT credentials in on_pre_connect; "
+                "will attempt reconnect with previous (possibly stale) tokens"
+            )
 
     def connect(self, event_loop=None) -> None:
         """Connect to the MQTT broker and start the network loop.
@@ -205,14 +245,11 @@ class MqttAwsBlueair:
             self._client.loop_stop()
             self._client.disconnect()
             self._connected = False
-        if self._reconnect_thread is not None:
-            self._reconnect_thread.join(timeout=10)
-            self._reconnect_thread = None
         self._client = None
 
     def _on_connect(self, client, userdata, flags, reason_code, properties):
         if reason_code == 0:
-            _LOGGER.debug(f"MQTT connected (devices={len(self._device_ids)})")
+            _LOGGER.info(f"MQTT connected successfully (devices={len(self._device_ids)})")
             self._connected = True
             # Subscribe to per-user event topic
             user_topic = f"c/{self._user_id}/s/event"
@@ -230,92 +267,19 @@ class MqttAwsBlueair:
         self._connected = False
         if reason_code == 0 or self._stopping:
             _LOGGER.info("MQTT disconnected cleanly")
-            if self.on_disconnect_callback:
-                self.on_disconnect_callback()
-            return
-
-        _LOGGER.debug(f"MQTT disconnected unexpectedly: reason_code={reason_code}")
+        else:
+            _LOGGER.warning(
+                f"MQTT disconnected unexpectedly: reason_code={reason_code}; "
+                f"paho will auto-reconnect with credential refresh"
+            )
         if self.on_disconnect_callback:
             self.on_disconnect_callback()
 
-        # Start reconnect with credential refresh in a background thread.
-        # We don't call loop_stop() here because we're on paho's network
-        # thread — it will exit naturally after this callback returns.
-        _LOGGER.debug("Starting MQTT reconnect loop with credential refresh")
-        if self._reconnect_thread is None or not self._reconnect_thread.is_alive():
-            self._reconnect_thread = threading.Thread(
-                target=self._reconnect_loop, daemon=True
-            )
-            self._reconnect_thread.start()
-
-    def _reconnect_loop(self) -> None:
-        """Reconnect with exponential backoff, refreshing credentials each attempt."""
-        delay = _RECONNECT_INITIAL_DELAY
-        broker = AWS_MQTT_BROKERS.get(self._region)
-        if broker is None:
-            _LOGGER.error(f"No MQTT broker for region {self._region}; cannot reconnect")
-            return
-        attempt = 0
-
-        while not self._stopping:
-            attempt += 1
-            _LOGGER.debug(f"MQTT reconnect attempt {attempt} in {delay}s...")
-            time.sleep(delay)
-            if self._stopping:
-                _LOGGER.info("MQTT reconnect cancelled (shutting down)")
-                return
-
-            # Paho's loop_start() may have auto-reconnected with stale
-            # credentials while we were sleeping. If so, tear it down
-            # and replace with a fresh-credential connection.
-            if self._connected:
-                _LOGGER.debug(
-                    "MQTT auto-reconnected with existing credentials; "
-                    "replacing with fresh credentials"
-                )
-
-            # Clean up the old client. By now paho's network thread has
-            # exited (we slept long enough), so loop_stop() is safe.
-            if self._client is not None:
-                self._client.loop_stop()
-                self._client = None
-
-            # Refresh credentials if a refresher is available.
-            if self.credential_refresher and self._event_loop:
-                try:
-                    future = asyncio.run_coroutine_threadsafe(
-                        self.credential_refresher(), self._event_loop
-                    )
-                    new_name, new_sig, new_token = future.result(timeout=30)
-                    self._mqtt_auth_name = new_name
-                    self._mqtt_auth_signature = new_sig
-                    self._mqtt_auth_token = new_token
-                    _LOGGER.debug("MQTT credentials refreshed successfully")
-                except Exception:
-                    _LOGGER.exception(
-                        f"Failed to refresh MQTT credentials (attempt {attempt}), "
-                        f"next retry in {min(delay * _RECONNECT_BACKOFF_FACTOR, _RECONNECT_MAX_DELAY)}s"
-                    )
-                    delay = min(delay * _RECONNECT_BACKOFF_FACTOR, _RECONNECT_MAX_DELAY)
-                    continue
-            elif not self.credential_refresher:
-                _LOGGER.warning(
-                    "No credential_refresher configured; reconnecting with existing tokens "
-                    "(may fail if tokens have expired)"
-                )
-
-            try:
-                self._client = self._build_client()
-                self._client.connect(broker, 443, keepalive=60)
-                self._client.loop_start()
-                _LOGGER.debug(f"MQTT reconnected with fresh credentials (attempt {attempt})")
-                return
-            except Exception:
-                _LOGGER.exception(
-                    f"MQTT reconnect attempt {attempt} failed, "
-                    f"next retry in {min(delay * _RECONNECT_BACKOFF_FACTOR, _RECONNECT_MAX_DELAY)}s"
-                )
-                delay = min(delay * _RECONNECT_BACKOFF_FACTOR, _RECONNECT_MAX_DELAY)
+    def _on_connect_fail(self, client, userdata):
+        _LOGGER.warning(
+            "MQTT connection attempt failed (TCP/TLS/WebSocket handshake error); "
+            "paho will retry with backoff"
+        )
 
     def _on_subscribe(self, client, userdata, mid, reason_codes, properties):
         _LOGGER.debug(f"MQTT subscription confirmed (mid={mid})")

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -268,7 +268,7 @@ class MqttAwsBlueair:
         if reason_code == 0 or self._stopping:
             _LOGGER.info("MQTT disconnected cleanly")
         else:
-            _LOGGER.warning(
+            _LOGGER.info(
                 f"MQTT disconnected unexpectedly: reason_code={reason_code}; "
                 f"paho will auto-reconnect with credential refresh"
             )

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -159,9 +159,8 @@ class MqttAwsBlueair:
         """Unsubscribe and re-subscribe to sensor topics for all devices.
 
         This resets the device-side TTL countdown, keeping the 5-second
-        sensor data stream alive.  Matches the Blueair app's
-        ``MqttService.resubscribeRt5s()`` pattern: unsubscribe first,
-        then subscribe.
+        sensor data stream alive.  The unsubscribe-then-subscribe cycle
+        signals the device to restart its publish timer.
 
         Safe to call from any thread — guards against client being
         None or disconnected (e.g. during shutdown race).
@@ -452,8 +451,7 @@ class MqttAwsBlueair:
         _LOGGER.debug(f"Device event for {device_id}: {event_type} ({payload.get('m', '')})")
 
         # When a device comes online, re-subscribe to its sensor topic
-        # to reset the TTL and start receiving 5s data.  This matches
-        # the Blueair app's SimpleMqttCallBack behavior.
+        # to reset the TTL and start receiving 5s data.
         client = self._client  # snapshot to avoid race with disconnect()
         if event_type == "Connected" and device_id and client is not None:
             topic = f"d/{device_id}/s/5s"

--- a/src/blueair_api/mqtt_aws_blueair.py
+++ b/src/blueair_api/mqtt_aws_blueair.py
@@ -156,11 +156,14 @@ class MqttAwsBlueair:
             _LOGGER.debug(f"Sensor TTL set to {ttl_seconds}s (re-subscribe every {int(ttl_seconds * _TTL_RESUBSCRIBE_RATIO)}s)")
 
     def _resubscribe_sensor_topics(self) -> None:
-        """Unsubscribe and re-subscribe to sensor topics for all devices.
+        """Re-subscribe to sensor topics for all devices.
 
         This resets the device-side TTL countdown, keeping the 5-second
-        sensor data stream alive.  The unsubscribe-then-subscribe cycle
-        signals the device to restart its publish timer.
+        sensor data stream alive.  Per MQTT spec, subscribing to an
+        already-subscribed topic is idempotent (broker sends SUBACK and
+        the subscription stays active).  We intentionally do NOT
+        unsubscribe first — the unsubscribe kills the device's data
+        push and the immediate re-subscribe doesn't always restart it.
 
         Safe to call from any thread — guards against client being
         None or disconnected (e.g. during shutdown race).
@@ -171,7 +174,6 @@ class MqttAwsBlueair:
         for device_uuid in self._device_ids:
             topic = f"d/{device_uuid}/s/5s"
             try:
-                client.unsubscribe(topic)
                 client.subscribe(topic)
                 _LOGGER.debug(f"Re-subscribed to {topic} (TTL keepalive)")
             except Exception:
@@ -456,7 +458,6 @@ class MqttAwsBlueair:
         if event_type == "Connected" and device_id and client is not None:
             topic = f"d/{device_id}/s/5s"
             try:
-                client.unsubscribe(topic)
                 client.subscribe(topic)
                 _LOGGER.info(f"Re-subscribed to {topic} (device Connected event)")
             except Exception:

--- a/tests/test_mqtt_aws_blueair.py
+++ b/tests/test_mqtt_aws_blueair.py
@@ -643,7 +643,7 @@ class TestSensorTTLResubscribe(TestCase):
         assert client._sensor_ttl == 1200
 
     def test_resubscribe_sensor_topics(self):
-        """_resubscribe_sensor_topics should unsubscribe then subscribe for each device."""
+        """_resubscribe_sensor_topics should subscribe (without unsubscribe) for each device."""
         client = make_mqtt_client()
         client.register_device(FAKE_DEVICE_UUID)
         mock_paho = mock.MagicMock()
@@ -652,7 +652,7 @@ class TestSensorTTLResubscribe(TestCase):
 
         client._resubscribe_sensor_topics()
 
-        mock_paho.unsubscribe.assert_called_once_with(f"d/{FAKE_DEVICE_UUID}/s/5s")
+        mock_paho.unsubscribe.assert_not_called()
         mock_paho.subscribe.assert_called_once_with(f"d/{FAKE_DEVICE_UUID}/s/5s")
 
     def test_resubscribe_sensor_topics_multiple_devices(self):
@@ -667,7 +667,7 @@ class TestSensorTTLResubscribe(TestCase):
 
         client._resubscribe_sensor_topics()
 
-        assert mock_paho.unsubscribe.call_count == 2
+        mock_paho.unsubscribe.assert_not_called()
         assert mock_paho.subscribe.call_count == 2
 
     def test_resubscribe_sensor_topics_not_connected(self):
@@ -769,8 +769,8 @@ class TestConnectedEventResubscribe(TestCase):
         msg = make_mqtt_message(f"c/{FAKE_USER_ID}/s/event", payload)
         client._on_message(None, None, msg)
 
-        # Should have unsubscribed then subscribed to the 5s topic
-        mock_paho.unsubscribe.assert_called_once_with(f"d/{FAKE_DEVICE_UUID}/s/5s")
+        # Should have re-subscribed to the 5s topic (no unsubscribe)
+        mock_paho.unsubscribe.assert_not_called()
         mock_paho.subscribe.assert_called_once_with(f"d/{FAKE_DEVICE_UUID}/s/5s")
 
     def test_not_connected_event_does_not_resubscribe(self):

--- a/tests/test_mqtt_aws_blueair.py
+++ b/tests/test_mqtt_aws_blueair.py
@@ -617,3 +617,178 @@ class TestOnConnectFail(TestCase):
         client = make_mqtt_client()
         # Should not raise
         client._on_connect_fail(None, None)
+
+
+class TestSensorTTLResubscribe(TestCase):
+    """Tests for the sensor TTL keepalive re-subscribe mechanism."""
+
+    def test_set_sensor_ttl(self):
+        """set_sensor_ttl should update the TTL value."""
+        client = make_mqtt_client()
+        client.set_sensor_ttl(600)
+        assert client._sensor_ttl == 600
+
+    def test_set_sensor_ttl_ignores_non_positive(self):
+        """set_sensor_ttl should ignore values <= 0."""
+        client = make_mqtt_client()
+        original = client._sensor_ttl
+        client.set_sensor_ttl(-1)
+        assert client._sensor_ttl == original
+        client.set_sensor_ttl(0)
+        assert client._sensor_ttl == original
+
+    def test_default_sensor_ttl(self):
+        """Default sensor TTL should be 1200 seconds."""
+        client = make_mqtt_client()
+        assert client._sensor_ttl == 1200
+
+    def test_resubscribe_sensor_topics(self):
+        """_resubscribe_sensor_topics should unsubscribe then subscribe for each device."""
+        client = make_mqtt_client()
+        client.register_device(FAKE_DEVICE_UUID)
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+        client._connected = True
+
+        client._resubscribe_sensor_topics()
+
+        mock_paho.unsubscribe.assert_called_once_with(f"d/{FAKE_DEVICE_UUID}/s/5s")
+        mock_paho.subscribe.assert_called_once_with(f"d/{FAKE_DEVICE_UUID}/s/5s")
+
+    def test_resubscribe_sensor_topics_multiple_devices(self):
+        """_resubscribe_sensor_topics should handle multiple devices."""
+        client = make_mqtt_client()
+        uuid2 = "22222222-2222-2222-2222-222222222222"
+        client.register_device(FAKE_DEVICE_UUID)
+        client.register_device(uuid2)
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+        client._connected = True
+
+        client._resubscribe_sensor_topics()
+
+        assert mock_paho.unsubscribe.call_count == 2
+        assert mock_paho.subscribe.call_count == 2
+
+    def test_resubscribe_sensor_topics_not_connected(self):
+        """_resubscribe_sensor_topics should be a no-op when not connected."""
+        client = make_mqtt_client()
+        client.register_device(FAKE_DEVICE_UUID)
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+        client._connected = False
+
+        client._resubscribe_sensor_topics()
+
+        mock_paho.unsubscribe.assert_not_called()
+        mock_paho.subscribe.assert_not_called()
+
+    def test_on_connect_starts_resubscribe_timer(self):
+        """_on_connect should start the re-subscribe timer."""
+        client = make_mqtt_client()
+        client.register_device(FAKE_DEVICE_UUID)
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+
+        client._on_connect(mock_paho, None, None, 0, None)
+
+        assert client._resubscribe_timer is not None
+        # Clean up
+        client._cancel_resubscribe_timer()
+
+    def test_disconnect_cancels_resubscribe_timer(self):
+        """disconnect() should cancel the re-subscribe timer."""
+        client = make_mqtt_client()
+        # Simulate a running timer
+        client._resubscribe_timer = mock.MagicMock()
+        client._client = mock.MagicMock()
+
+        client.disconnect()
+
+        assert client._resubscribe_timer is None
+
+    def test_unexpected_disconnect_cancels_timer(self):
+        """_on_disconnect should cancel the re-subscribe timer."""
+        client = make_mqtt_client()
+        client._resubscribe_timer = mock.MagicMock()
+
+        client._on_disconnect(None, None, None, 7, None)
+
+        assert client._resubscribe_timer is None
+
+    def test_resubscribe_timer_interval(self):
+        """Timer interval should be TTL * 0.75."""
+        client = make_mqtt_client()
+        client.set_sensor_ttl(1200)
+        client.register_device(FAKE_DEVICE_UUID)
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+        client._connected = True
+
+        with mock.patch('blueair_api.mqtt_aws_blueair.threading.Timer') as MockTimer:
+            mock_timer_instance = mock.MagicMock()
+            MockTimer.return_value = mock_timer_instance
+            client._start_resubscribe_timer()
+            MockTimer.assert_called_once_with(900, client._resubscribe_timer_fired)
+            mock_timer_instance.start.assert_called_once()
+
+        client._cancel_resubscribe_timer()
+
+    def test_resubscribe_timer_custom_ttl(self):
+        """Timer interval should use custom TTL when set."""
+        client = make_mqtt_client()
+        client.set_sensor_ttl(600)  # 10 minutes
+
+        with mock.patch('blueair_api.mqtt_aws_blueair.threading.Timer') as MockTimer:
+            mock_timer_instance = mock.MagicMock()
+            MockTimer.return_value = mock_timer_instance
+            client._start_resubscribe_timer()
+            MockTimer.assert_called_once_with(450, client._resubscribe_timer_fired)
+
+        client._cancel_resubscribe_timer()
+
+
+class TestConnectedEventResubscribe(TestCase):
+    """Tests for re-subscribing on device Connected events."""
+
+    def test_connected_event_resubscribes(self):
+        """A Connected event should trigger re-subscribe for that device."""
+        client = make_mqtt_client()
+        client.register_device(FAKE_DEVICE_UUID)
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+        client._connected = True
+
+        payload = {
+            "et": "Connected",
+            "o": FAKE_DEVICE_UUID,
+            "ts": 1776455065,
+            "m": "Device is Online",
+            "ot": "ConnectionEvent",
+        }
+        msg = make_mqtt_message(f"c/{FAKE_USER_ID}/s/event", payload)
+        client._on_message(None, None, msg)
+
+        # Should have unsubscribed then subscribed to the 5s topic
+        mock_paho.unsubscribe.assert_called_once_with(f"d/{FAKE_DEVICE_UUID}/s/5s")
+        mock_paho.subscribe.assert_called_once_with(f"d/{FAKE_DEVICE_UUID}/s/5s")
+
+    def test_not_connected_event_does_not_resubscribe(self):
+        """A NotConnected event should NOT trigger re-subscribe."""
+        client = make_mqtt_client()
+        client.register_device(FAKE_DEVICE_UUID)
+        mock_paho = mock.MagicMock()
+        client._client = mock_paho
+        client._connected = True
+
+        payload = {
+            "et": "NotConnected",
+            "o": FAKE_DEVICE_UUID,
+            "ts": 1776455065,
+            "m": "Device is Offline",
+        }
+        msg = make_mqtt_message(f"c/{FAKE_USER_ID}/s/event", payload)
+        client._on_message(None, None, msg)
+
+        mock_paho.unsubscribe.assert_not_called()
+        mock_paho.subscribe.assert_not_called()

--- a/tests/test_mqtt_aws_blueair.py
+++ b/tests/test_mqtt_aws_blueair.py
@@ -2,12 +2,11 @@
 
 Unit tests that mock the paho-mqtt client to verify message parsing,
 topic routing, callback dispatch, device registration, and reconnection
-with credential refresh.
+with credential refresh via paho's on_pre_connect hook.
 """
 import asyncio
 import json
 import threading
-import time
 from unittest import TestCase, mock
 
 from blueair_api.mqtt_aws_blueair import MqttAwsBlueair
@@ -205,10 +204,10 @@ class TestDeviceRegistration(TestCase):
 
 
 class TestDisconnectReconnect(TestCase):
-    """Tests for disconnect handling and reconnect with credential refresh."""
+    """Tests for disconnect handling and credential refresh via on_pre_connect."""
 
-    def test_clean_disconnect_no_reconnect(self):
-        """A clean disconnect (reason_code=0) should not trigger reconnect."""
+    def test_clean_disconnect_no_warning(self):
+        """A clean disconnect (reason_code=0) should not log a warning."""
         client = make_mqtt_client()
         client._stopping = False
         mock_paho = mock.MagicMock()
@@ -217,11 +216,9 @@ class TestDisconnectReconnect(TestCase):
         client._on_disconnect(mock_paho, None, None, 0, None)
 
         assert client._connected is False
-        # No reconnect thread should be started
-        assert client._reconnect_thread is None
 
-    def test_stopping_disconnect_no_reconnect(self):
-        """When _stopping is True, no reconnect should happen."""
+    def test_stopping_disconnect(self):
+        """When _stopping is True, disconnect should be clean."""
         client = make_mqtt_client()
         client._stopping = True
         mock_paho = mock.MagicMock()
@@ -230,24 +227,18 @@ class TestDisconnectReconnect(TestCase):
         client._on_disconnect(mock_paho, None, None, 7, None)
 
         assert client._connected is False
-        assert client._reconnect_thread is None
 
-    def test_unexpected_disconnect_triggers_reconnect(self):
-        """An unexpected disconnect should start reconnect thread."""
+    def test_unexpected_disconnect_sets_not_connected(self):
+        """An unexpected disconnect should set connected to False."""
         client = make_mqtt_client()
+        client._connected = True
         client._stopping = False
         mock_paho = mock.MagicMock()
         client._client = mock_paho
 
-        # Prevent the reconnect thread from actually running forever
-        with mock.patch.object(client, '_reconnect_loop'):
-            client._on_disconnect(mock_paho, None, None, 7, None)
+        client._on_disconnect(mock_paho, None, None, 7, None)
 
         assert client._connected is False
-        # loop_stop is NOT called here (we're on paho's thread);
-        # it happens in _reconnect_loop instead.
-        mock_paho.loop_stop.assert_not_called()
-        assert client._reconnect_thread is not None
 
     def test_disconnect_callback_fires(self):
         """on_disconnect_callback should fire on unexpected disconnect."""
@@ -258,16 +249,13 @@ class TestDisconnectReconnect(TestCase):
         callback_fired = []
         client.on_disconnect_callback = lambda: callback_fired.append(True)
 
-        with mock.patch.object(client, '_reconnect_loop'):
-            client._on_disconnect(mock_paho, None, None, 7, None)
+        client._on_disconnect(mock_paho, None, None, 7, None)
 
         assert len(callback_fired) == 1
 
-    @mock.patch('blueair_api.mqtt_aws_blueair.time.sleep')
-    def test_reconnect_loop_refreshes_credentials(self, mock_sleep):
-        """_reconnect_loop should call credential_refresher and reconnect."""
+    def test_on_pre_connect_refreshes_credentials(self):
+        """on_pre_connect should call credential_refresher and update tokens."""
         client = make_mqtt_client()
-        client._stopping = False
 
         loop = asyncio.new_event_loop()
         loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
@@ -279,10 +267,7 @@ class TestDisconnectReconnect(TestCase):
 
         client.credential_refresher = fake_refresh
 
-        # Make _build_client return a mock, then stop the loop after one cycle
-        mock_paho = mock.MagicMock()
-        with mock.patch.object(client, '_build_client', return_value=mock_paho):
-            client._reconnect_loop()
+        client._on_pre_connect(None, None)
 
         loop.call_soon_threadsafe(loop.stop)
         loop_thread.join(timeout=5)
@@ -291,58 +276,78 @@ class TestDisconnectReconnect(TestCase):
         assert client._mqtt_auth_name == "new-name"
         assert client._mqtt_auth_signature == "new-sig"
         assert client._mqtt_auth_token == "new-token"
-        mock_paho.connect.assert_called_once()
-        mock_paho.loop_start.assert_called_once()
 
-    @mock.patch('blueair_api.mqtt_aws_blueair.time.sleep')
-    def test_reconnect_loop_retries_on_refresh_failure(self, mock_sleep):
-        """If credential refresh fails, it should retry with backoff."""
+    def test_on_pre_connect_handles_refresh_failure(self):
+        """If credential refresh fails, on_pre_connect should not crash."""
         client = make_mqtt_client()
-        client._stopping = False
 
         loop = asyncio.new_event_loop()
         loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
         loop_thread.start()
         client._event_loop = loop
 
-        call_count = 0
+        async def failing_refresh():
+            raise RuntimeError("network error")
 
-        async def failing_then_ok_refresh():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise RuntimeError("network error")
-            return ("new-name", "new-sig", "new-token")
+        client.credential_refresher = failing_refresh
 
-        client.credential_refresher = failing_then_ok_refresh
-
-        mock_paho = mock.MagicMock()
-        with mock.patch.object(client, '_build_client', return_value=mock_paho):
-            client._reconnect_loop()
+        # Should not raise
+        client._on_pre_connect(None, None)
 
         loop.call_soon_threadsafe(loop.stop)
         loop_thread.join(timeout=5)
         loop.close()
 
-        assert call_count == 2
-        # First call sleeps 5s, second call sleeps 10s (backoff)
-        assert mock_sleep.call_count == 2
-        mock_sleep.assert_any_call(5)
-        mock_sleep.assert_any_call(10)
+        # Credentials should remain unchanged
+        assert client._mqtt_auth_name == "custom-authorizer"
 
-    @mock.patch('blueair_api.mqtt_aws_blueair.time.sleep')
-    def test_reconnect_loop_stops_when_stopping(self, mock_sleep):
-        """_reconnect_loop should exit when _stopping is set."""
+    def test_on_pre_connect_skips_without_refresher(self):
+        """on_pre_connect should be a no-op without a credential_refresher."""
+        client = make_mqtt_client()
+        client._event_loop = asyncio.new_event_loop()
+        client.credential_refresher = None
+
+        # Should not raise
+        client._on_pre_connect(None, None)
+
+        client._event_loop.close()
+
+    def test_on_pre_connect_skips_without_event_loop(self):
+        """on_pre_connect should be a no-op without an event loop."""
+        client = make_mqtt_client()
+        client._event_loop = None
+
+        async def fake_refresh():
+            return ("n", "s", "t")
+
+        client.credential_refresher = fake_refresh
+
+        # Should not raise
+        client._on_pre_connect(None, None)
+
+    def test_get_ws_headers_returns_current_creds(self):
+        """_get_ws_headers should return the current auth credentials."""
         client = make_mqtt_client()
 
-        # Set stopping before sleep returns
-        def stop_on_sleep(delay):
-            client._stopping = True
+        headers = client._get_ws_headers({"Host": "example.com"})
 
-        mock_sleep.side_effect = stop_on_sleep
+        assert headers["X-Amz-CustomAuthorizer-Name"] == "custom-authorizer"
+        assert headers["X-Amz-CustomAuthorizer-Signature"] == "fake-signature"
+        assert headers["X-Amz-CustomAuthorizer-Token"] == "fake-token"
+        assert headers["Host"] == "example.com"
 
-        client._reconnect_loop()
-        # Should exit without error
+    def test_get_ws_headers_reflects_refreshed_creds(self):
+        """After credential refresh, _get_ws_headers should return new tokens."""
+        client = make_mqtt_client()
+        client._mqtt_auth_name = "updated-name"
+        client._mqtt_auth_signature = "updated-sig"
+        client._mqtt_auth_token = "updated-token"
+
+        headers = client._get_ws_headers({})
+
+        assert headers["X-Amz-CustomAuthorizer-Name"] == "updated-name"
+        assert headers["X-Amz-CustomAuthorizer-Signature"] == "updated-sig"
+        assert headers["X-Amz-CustomAuthorizer-Token"] == "updated-token"
 
     def test_register_device_while_connected_subscribes(self):
         """Registering a device while connected should subscribe immediately."""
@@ -467,3 +472,148 @@ class TestInvalidRegion(TestCase):
         )
         with self.assertRaises(ValueError):
             client.connect()
+
+
+class TestBuildClient(TestCase):
+    """Tests that _build_client wires up paho hooks correctly."""
+
+    def test_build_client_sets_on_pre_connect(self):
+        """_build_client must assign on_pre_connect for credential refresh."""
+        client = make_mqtt_client()
+        paho_client = client._build_client()
+        assert paho_client.on_pre_connect is not None
+        assert paho_client.on_pre_connect == client._on_pre_connect
+
+    def test_build_client_sets_on_connect_fail(self):
+        """_build_client must assign on_connect_fail for logging handshake errors."""
+        client = make_mqtt_client()
+        paho_client = client._build_client()
+        assert paho_client.on_connect_fail is not None
+        assert paho_client.on_connect_fail == client._on_connect_fail
+
+    def test_build_client_sets_callable_headers(self):
+        """_build_client must pass a callable (not a dict) to ws_set_options."""
+        client = make_mqtt_client()
+        paho_client = client._build_client()
+        # paho stores the callable in _websocket_extra_headers
+        assert callable(paho_client._websocket_extra_headers)
+
+    def test_build_client_enables_reconnect(self):
+        """_build_client must leave reconnect_on_failure enabled (default True)."""
+        client = make_mqtt_client()
+        paho_client = client._build_client()
+        assert paho_client._reconnect_on_failure is True
+
+    def test_build_client_sets_reconnect_delay(self):
+        """_build_client must configure backoff via reconnect_delay_set."""
+        client = make_mqtt_client()
+        paho_client = client._build_client()
+        assert paho_client._reconnect_min_delay == 5
+        assert paho_client._reconnect_max_delay == 300
+
+
+class TestEndToEndCredentialRefresh(TestCase):
+    """Test the full reconnect credential flow: on_pre_connect → _get_ws_headers."""
+
+    def test_pre_connect_then_headers_returns_fresh_creds(self):
+        """Simulates paho's reconnect: on_pre_connect refreshes, then
+        _get_ws_headers returns the new values for the WS handshake."""
+        client = make_mqtt_client()
+
+        loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+        loop_thread.start()
+        client._event_loop = loop
+
+        async def fake_refresh():
+            return ("refreshed-name", "refreshed-sig", "refreshed-token")
+
+        client.credential_refresher = fake_refresh
+
+        # Step 1: paho calls on_pre_connect
+        client._on_pre_connect(None, None)
+
+        # Step 2: paho calls _get_ws_headers during WS handshake
+        headers = client._get_ws_headers({"Host": "broker.example.com"})
+
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=5)
+        loop.close()
+
+        assert headers["X-Amz-CustomAuthorizer-Name"] == "refreshed-name"
+        assert headers["X-Amz-CustomAuthorizer-Signature"] == "refreshed-sig"
+        assert headers["X-Amz-CustomAuthorizer-Token"] == "refreshed-token"
+        # Default headers preserved
+        assert headers["Host"] == "broker.example.com"
+
+    def test_pre_connect_failure_headers_use_old_creds(self):
+        """If credential refresh fails, headers should still use the
+        previous (possibly stale) credentials rather than crashing."""
+        client = make_mqtt_client()
+
+        loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+        loop_thread.start()
+        client._event_loop = loop
+
+        async def failing_refresh():
+            raise RuntimeError("auth server down")
+
+        client.credential_refresher = failing_refresh
+
+        # on_pre_connect fails silently
+        client._on_pre_connect(None, None)
+
+        # Headers should still work with original creds
+        headers = client._get_ws_headers({})
+
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=5)
+        loop.close()
+
+        assert headers["X-Amz-CustomAuthorizer-Name"] == "custom-authorizer"
+        assert headers["X-Amz-CustomAuthorizer-Signature"] == "fake-signature"
+        assert headers["X-Amz-CustomAuthorizer-Token"] == "fake-token"
+
+
+class TestConnectDisconnect(TestCase):
+    """Tests for connect() and disconnect() methods."""
+
+    @mock.patch('blueair_api.mqtt_aws_blueair.mqtt.Client')
+    def test_connect_stores_event_loop(self, MockClient):
+        """connect() should store the event_loop for on_pre_connect."""
+        client = make_mqtt_client()
+        fake_loop = mock.MagicMock()
+        client.connect(event_loop=fake_loop)
+        assert client._event_loop is fake_loop
+
+    @mock.patch('blueair_api.mqtt_aws_blueair.mqtt.Client')
+    def test_connect_calls_paho_connect_and_loop_start(self, MockClient):
+        """connect() should call paho's connect() and loop_start()."""
+        mock_paho = MockClient.return_value
+        client = make_mqtt_client()
+        client.connect()
+        mock_paho.connect.assert_called_once()
+        mock_paho.loop_start.assert_called_once()
+
+    @mock.patch('blueair_api.mqtt_aws_blueair.mqtt.Client')
+    def test_disconnect_calls_paho_loop_stop_and_disconnect(self, MockClient):
+        """disconnect() should call loop_stop() and disconnect() on paho."""
+        mock_paho = MockClient.return_value
+        client = make_mqtt_client()
+        client.connect()
+        client.disconnect()
+        mock_paho.loop_stop.assert_called_once()
+        mock_paho.disconnect.assert_called_once()
+        assert client._stopping is True
+        assert client._client is None
+
+
+class TestOnConnectFail(TestCase):
+    """Tests for the on_connect_fail handler."""
+
+    def test_on_connect_fail_does_not_crash(self):
+        """on_connect_fail should log but not raise."""
+        client = make_mqtt_client()
+        # Should not raise
+        client._on_connect_fail(None, None)


### PR DESCRIPTION
Replace the custom reconnect thread with paho's built-in reconnect loop. The previous approach disabled `_reconnect_on_failure` and spawned a custom thread from `on_disconnect`, which caused silent connection death when paho's `loop_forever()` thread exited without reconnecting.

Fixes dahlb/ha_blueair#328

## Problem

Two separate issues were causing MQTT data loss:

### 1. Silent connection death after disconnect

When the MQTT connection dropped (AWS IoT disconnects every ~60 minutes), the custom reconnect thread relied on `on_disconnect` to spawn it. But with `_reconnect_on_failure = False`, paho's `loop_forever()` thread exits immediately on connection loss — it's a daemon thread, so it dies silently with no log, no exception, no notification. The custom reconnect thread ran on the same dying paho thread, creating a race condition.

**Result**: MQTT silently dies, the paho thread disappears, and nothing in the system notices until the next HTTP poll.

### 2. Expired JWT tokens block reconnection permanently

The MQTT credential refresh uses the authentication token to obtain new AWS IoT tokens, but the JWT has a very short lifetime (~5 minutes). After the initial login, the library was caching and reusing that JWT indefinitely. When the MQTT connection dropped and the reconnect loop tried to get fresh credentials, it sent the expired JWT to the Blueair API and got back `401 Id Token Expired`. Because the stale JWT was never cleared, every subsequent retry hit the same error — the reconnect loop got stuck permanently at 300s backoff intervals.

### 3. TTL keepalive causing data gaps (found via user logs)

After fixing reconnection, a periodic TTL keepalive timer was added to prevent device-side sensor stream expiry (devices stop publishing after 20 minutes). The initial implementation used an `unsubscribe()` + `subscribe()` cycle every 15 minutes. Analysis of a user's 24-hour debug log (3 devices, Blue Pure 511i Max) revealed that **every single data gap correlated exactly with a keepalive fire time** — the `unsubscribe` kills the device's data push, and the immediate re-subscribe doesn't always restart it within the same MQTT session.

## Solution

### Paho-native reconnect

Uses three paho-native hooks designed for this use case:

1. **`on_pre_connect`** — paho calls this synchronously before each reconnect attempt. We use it to call the async `credential_refresher` (which does a full re-authentication: session → JWT → access token) and update the stored auth credentials.

2. **`ws_set_options(headers=callable)`** — instead of passing a static dict of WebSocket auth headers, we pass a callable that returns the current credentials on every WebSocket handshake, including reconnects.

3. **`reconnect_delay_set(min_delay=5, max_delay=300)`** — paho's built-in exponential backoff handles retry timing.

### Subscribe-only TTL keepalive

Removed `unsubscribe()` from the periodic keepalive. Per [MQTT 3.1.1 §3.8.4](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718063), subscribing to an already-subscribed topic is idempotent — the broker treats it as replacing the existing subscription and sends SUBACK. A subscribe-only keepalive resets the device-side TTL without interrupting the active data stream.

### Reconnect flow

```
connection lost → on_disconnect fires (INFO logged)
  → paho waits 5s (backoff)
  → on_pre_connect refreshes credentials
  → WebSocket handshake uses fresh tokens via callable headers
  → on_connect re-subscribes to all device topics
  → sensor TTL keepalive timer restarts
  → data resumes
```

No custom threads, no race conditions, no silent failures.

## Testing

### Unit tests

54 tests covering the MQTT module (reconnect flow, credential refresh, TTL keepalive, Connected event re-subscribe, edge cases).

### Live testing — single device (author)

1-hour continuity monitor test:

| Metric | Result |
|--------|--------|
| Duration | 1 hour |
| Total messages | 720 |
| Minutes with data | **61/61 (100%)** |
| Data gaps | **NONE** |
| Keepalive boundaries crossed | 4 (at +15m, +30m, +45m, +60m) |
| Gaps at keepalive marks | **0** |

### Live testing — single device, 47-hour run (author, on Home Assistant)

| Metric | Result |
|--------|--------|
| Duration | **46 hours 41 min** |
| Reconnects | **46/46 (100%)** |
| Failed reconnects | 0 |
| `Id Token Expired` errors | **0** |
| Minutes with sensor data | **2,802** |
| Data gaps (>1 min) | **NONE** |
| 24h token boundary crossed | **Yes** (twice) |

## Changes

- `src/blueair_api/mqtt_aws_blueair.py` — reconnect rewrite, subscribe-only TTL keepalive
- `tests/test_mqtt_aws_blueair.py` — 54 tests covering the new flow
- `docs/mqtt.md` — documentation of reconnect architecture and sensor TTL
