### PR TITLE
fix: handle non-scalar vj values in SensorPack

### DIFF
--- a/src/blueair_api/intermediate_representation_aws.py
+++ b/src/blueair_api/intermediate_representation_aws.py
@@ -177,7 +177,10 @@ class SensorPack(list[Record]):
             rv : float | bool | str | bytes | None = None
             for label, value in record.items():
                 _LOGGER.debug(f"parsing senml record field {label} with value {value}")
-                assert isinstance(value, str | int | float | bool)
+                if not isinstance(value, str | int | float | bool):
+                    # Skip non-scalar values (e.g. 'vj' alarm JSON dicts).
+                    _LOGGER.debug(f"skipping non-scalar senml field {label}")
+                    continue
                 match label:
                     case 'bn' | 'bt' | 'bu' | 'bv' | 'bs' | 'bver':
                         raise ValueError("TODO: base fields not supported. c.f. RFC8428, 4.1")
@@ -193,6 +196,8 @@ class SensorPack(list[Record]):
                         rv = str(value)
                     case 'vd':
                         rv = bytes(base64.b64decode(str(value)))
+                    case 'vj':
+                        rv = value
                     case 'n':
                         rn = str(value)
                     case 'u':

--- a/tests/device_info/mini_restful.json
+++ b/tests/device_info/mini_restful.json
@@ -1,0 +1,306 @@
+{
+  "id": "122736c9-94b7-4da5-983f-8d61bb7f0fd0",
+  "configuration": {
+    "df": {
+      "a": 877,
+      "ot": "MiniRestful_Filter",
+      "fsfc": 18000000,
+      "yfsfc": 0,
+      "wfsfc": 0,
+      "alg": "FilterAlg1"
+    },
+    "di": {
+      "cfv": "1.0.1",
+      "cma": "30:ed:a0:8e:db:30",
+      "mt": "1",
+      "name": "Bedroom Air Purifier",
+      "sku": "113836",
+      "mfv": "1.2.9",
+      "ywrme": false,
+      "ofv": "1.2.9",
+      "hw": "mrest",
+      "ds": "111383600201111210001674"
+    },
+    "_ot": "CmConfig",
+    "_f": false,
+    "_it": "urn:blueair:openapi:version:iotmodule:0.0.5",
+    "_eid": "9e88402a-a10a-4c67-bd53-f2a041247296",
+    "_sc": "Instance",
+    "ds": {
+      "rt1s": {
+        "tf": "senml+json",
+        "ot": "RT1s",
+        "e": false,
+        "i": 1000,
+        "tn": "d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/s/1s",
+        "sn": [
+          "rssi"
+        ],
+        "ttl": 0,
+        "n": "rt1s",
+        "fe": true
+      },
+      "rssi": {
+        "tf": "senml+json",
+        "ot": "RSSI",
+        "e": true,
+        "i": 0,
+        "tn": "d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/s/rssi",
+        "ttl": 0,
+        "n": "rssi",
+        "fe": true
+      },
+      "rt5s": {
+        "tf": "senml+json",
+        "ot": "RT5s",
+        "e": false,
+        "i": 0,
+        "tn": "d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/s/5s",
+        "sn": [
+          "rssi"
+        ],
+        "ttl": -1,
+        "n": "rt5s",
+        "fe": true
+      },
+      "b5m": {
+        "tf": "senml+json",
+        "th": [
+          "5kb",
+          "300s"
+        ],
+        "ot": "Batch5m",
+        "e": true,
+        "i": 300000,
+        "tn": "$aws/rules/telemetry_ingest_rule/d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/s/batch/b5m",
+        "sn": [
+          "fsp0"
+        ],
+        "ttl": -1,
+        "n": "b5m",
+        "fe": true
+      },
+      "fsp0": {
+        "st": "fsp0",
+        "tf": "senml+json",
+        "t": 10,
+        "ot": "Fanspeed",
+        "e": true,
+        "i": 0,
+        "tn": "d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/s/fsp0",
+        "sn": [
+          "fsp0"
+        ],
+        "ttl": -1,
+        "n": "fsp0",
+        "fe": true
+      },
+      "rt5m": {
+        "tf": "senml+json",
+        "ot": "RT5m",
+        "e": false,
+        "i": 300000,
+        "tn": "d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/s/5m",
+        "sn": [
+          "rssi"
+        ],
+        "ttl": 0,
+        "n": "rt5m",
+        "fe": true
+      }
+    },
+    "_r": "us-east-2",
+    "_s": {
+      "sig": "f0c10b4077ba9b15ff1071249d115638755e78d9445b60d9a6035b5ac7b2357c",
+      "salg": "SHA256"
+    },
+    "_t": "Partial",
+    "_v": 1772921444,
+    "_cas": 1772910119,
+    "_id": "122736c9-94b7-4da5-983f-8d61bb7f0fd0",
+    "fc": {
+      "bssid": "",
+      "pwd": "9102revreSyrotcaF",
+      "ssid": "",
+      "url": ""
+    },
+    "da": {
+      "reboot": {
+        "p": false,
+        "a": false,
+        "ot": "Reboot",
+        "e": true,
+        "tn": "d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/a/reboot",
+        "n": "reboot",
+        "fe": true
+      },
+      "sflu": {
+        "p": false,
+        "a": false,
+        "ot": "SensorFlush",
+        "e": true,
+        "tn": "d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/a/sflu",
+        "n": "sflu",
+        "fe": true
+      },
+      "fsp0": {
+        "p": true,
+        "st": "fsp0",
+        "a": 20,
+        "tf": "senml+json",
+        "ot": "Fanspeed",
+        "e": true,
+        "tn": "d/122736c9-94b7-4da5-983f-8d61bb7f0fd0/a/fsp0",
+        "n": "fsp0",
+        "fe": true
+      }
+    },
+    "dc": {
+      "cfv": {
+        "d": "di.cfv",
+        "t": "integer",
+        "v": 0,
+        "n": "cfv"
+      },
+      "fanspeed": {
+        "a": "fsp0",
+        "s": "fsp0",
+        "t": "integer",
+        "v": 11,
+        "n": "fanspeed"
+      },
+      "ofv": {
+        "d": "di.ofv",
+        "t": "integer",
+        "v": 0,
+        "n": "ofv"
+      }
+    }
+  },
+  "alarms": [],
+  "events": [],
+  "sensordata": [],
+  "states": [
+    {
+      "n": "alarm1",
+      "vj": {"n": "Alarm", "e": true, "t": 25200, "l": true, "ld": 30, "s": 0, "v": 50, "r": 31},
+      "t": 1773773367
+    },
+    {
+      "n": "alarm6",
+      "vj": "null",
+      "t": 1773773367
+    },
+    {
+      "n": "nlstepless",
+      "v": 0,
+      "t": 1773763574
+    },
+    {
+      "n": "standby",
+      "vb": false,
+      "t": 1773716705
+    },
+    {
+      "n": "timstate",
+      "v": 0,
+      "t": 1773716704
+    },
+    {
+      "n": "timl",
+      "v": 0,
+      "t": 1773716704
+    },
+    {
+      "n": "timts",
+      "v": 0,
+      "t": 1773716704
+    },
+    {
+      "n": "timdur",
+      "v": 7200,
+      "t": 1773716704
+    },
+    {
+      "n": "mfv",
+      "v": 16777737,
+      "t": 1773716705
+    },
+    {
+      "n": "mainmode",
+      "v": 0,
+      "t": 1773716706
+    },
+    {
+      "n": "apsubmode",
+      "v": 1,
+      "t": 1773722527
+    },
+    {
+      "n": "brightness",
+      "v": 40,
+      "t": 1773716706
+    },
+    {
+      "n": "cfv",
+      "v": 16777217,
+      "t": 1773716706
+    },
+    {
+      "n": "ofv",
+      "v": 16777737,
+      "t": 1773716706
+    },
+    {
+      "n": "fanspeed",
+      "v": 51,
+      "t": 1773763386
+    },
+    {
+      "n": "filterusage",
+      "v": 3,
+      "t": 1773716707
+    },
+    {
+      "n": "childlock",
+      "vb": false,
+      "t": 1773716707
+    },
+    {
+      "n": "alarm2",
+      "vj": "null",
+      "t": 1773716707
+    },
+    {
+      "n": "alarm4",
+      "vj": "null",
+      "t": 1773716707
+    },
+    {
+      "n": "alarm5",
+      "vj": "null",
+      "t": 1773716707
+    },
+    {
+      "n": "alarm3",
+      "vj": "null",
+      "t": 1773716707
+    },
+    {
+      "n": "hourformat",
+      "vb": false,
+      "t": 1773716709
+    },
+    {
+      "t": 1773716709,
+      "vb": true,
+      "n": "online"
+    }
+  ],
+  "welcomehome": {
+    "setting": []
+  },
+  "fleet_info": [],
+  "location_id": "",
+  "timezone": "America/Detroit"
+}

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -991,6 +991,68 @@ class NullValueTest(DeviceAwsTestBase):
             assert device.water_level is NotImplemented
 
 
+class MiniRestfulAlarmTest(DeviceAwsTestBase):
+    """Tests for Mini Restful with active sunrise alarm.
+
+    When a sunrise alarm is active, the alarm1 state field has a vj
+    value that is a JSON dict instead of the string "null". This
+    previously crashed SensorPack with an AssertionError.
+    See: https://github.com/dahlb/ha_blueair/issues/334
+    """
+
+    def setUp(self):
+        super().setUp()
+        with open(resources.files().joinpath('device_info/mini_restful.json')) as sample_file:
+            info = json.load(sample_file)
+        self.device_info_helper.info.update(info)
+
+    async def test_refresh_with_active_alarm(self):
+        """refresh() should not crash when alarm1 has a dict vj value."""
+        await self.device.refresh()
+
+        with assert_fully_checked(self.device) as device:
+            assert device.model_name == "Blueair Mini Restful"
+            assert device.hw == "mrest"
+            assert device.brightness == 40
+            assert device.fan_speed == 51
+            assert device.standby is False
+            assert device.child_lock is False
+            assert device.filter_usage_percentage == 3
+            assert device.main_mode == 0
+            assert device.ap_sub_mode == 1
+            assert device.wifi_working is True
+            assert device.sku == "113836"
+            assert device.firmware == "1.0.1"
+            assert device.mcu_firmware == "1.2.9"
+            assert device.serial_number == "111383600201111210001674"
+            assert device.name == "Bedroom Air Purifier"
+
+            assert device.pm1 is NotImplemented
+            assert device.pm2_5 is NotImplemented
+            assert device.pm10 is NotImplemented
+            assert device.total_voc is NotImplemented
+            assert device.voc is NotImplemented
+            assert device.temperature is NotImplemented
+            assert device.humidity is NotImplemented
+            assert device.night_mode is NotImplemented
+            assert device.germ_shield is NotImplemented
+            assert device.fan_auto_mode is NotImplemented
+            assert device.wick_usage_percentage is NotImplemented
+            assert device.auto_regulated_humidity is NotImplemented
+            assert device.water_shortage is NotImplemented
+            assert device.wick_dry_mode is NotImplemented
+            assert device.heat_temp is NotImplemented
+            assert device.heat_sub_mode is NotImplemented
+            assert device.heat_fan_speed is NotImplemented
+            assert device.cool_sub_mode is NotImplemented
+            assert device.cool_fan_speed is NotImplemented
+            assert device.fan_speed_0 is None
+            assert device.temperature_unit is NotImplemented
+            assert device.mood_brightness is NotImplemented
+            assert device.water_refresher_usage_percentage is NotImplemented
+            assert device.water_level is NotImplemented
+
+
 class OnlineStateTest(DeviceAwsTestBase):
     """Tests for wifi_working behavior.
 

--- a/tests/test_intermediate_representation_aws.py
+++ b/tests/test_intermediate_representation_aws.py
@@ -150,6 +150,36 @@ class SensorPackTest(TestCase):
     latest = sp.to_latest()
     assert latest['missing_t'].value == 2
 
+  def testVjNullString(self):
+    """Alarm fields with vj='null' should parse without crashing."""
+    sp = ir.SensorPack([
+            {'n': 'alarm1', 'vj': 'null', 't': 100},
+    ])
+    latest = sp.to_latest()
+    assert latest['alarm1'].value == 'null'
+
+  def testVjAlarmDict(self):
+    """Alarm fields with vj=dict should skip the dict and not crash."""
+    alarm_obj = {'n': 'Alarm', 'e': True, 't': 25200, 'l': True, 'ld': 30, 's': 0, 'v': 50, 'r': 31}
+    sp = ir.SensorPack([
+            {'n': 'alarm1', 'vj': alarm_obj, 't': 200},
+    ])
+    latest = sp.to_latest()
+    # The dict is skipped by the non-scalar guard, so value stays None.
+    assert latest['alarm1'].value is None
+
+  def testMixedScalarAndNonScalar(self):
+    """Records with both scalar and non-scalar fields parse correctly."""
+    sp = ir.SensorPack([
+            {'n': 'fanspeed', 'v': 51, 't': 100},
+            {'n': 'alarm1', 'vj': {'n': 'Alarm', 'e': True}, 't': 100},
+            {'n': 'standby', 'vb': False, 't': 100},
+    ])
+    latest = sp.to_latest()
+    assert latest['fanspeed'].value == 51
+    assert latest['standby'].value is False
+    assert latest['alarm1'].value is None
+
 
 class QueryJsonTest(TestCase):
 


### PR DESCRIPTION
Fixes dahlb/ha_blueair#344

## Problem

The `SensorPack` parser in `intermediate_representation_aws.py` asserts that all SenML record values are scalars (`str | int | float | bool`). However, the Mini Restful device's alarm fields (`alarm1`–`alarm6`) use the `vj` (value JSON) SenML label, whose value is a JSON dict when a sunrise alarm is active:

```json
{"n": "alarm1", "vj": {"hour": 7, "minute": 0, "enabled": true, ...}}
```

This causes an `AssertionError` crash on every `refresh()` call for any Mini Restful device with an active alarm, making the device completely unresponsive in Home Assistant.

## Solution

- Replace the `assert isinstance(...)` with a guard that **skips and logs** non-scalar values, so the parser doesn't crash on unexpected types
- Add a `vj` case to the SenML `match` statement for string `vj` values (per [RFC 8428 §5.3](https://www.rfc-editor.org/rfc/rfc8428.html#section-5.3))

The alarm data itself is not consumed by any entity today, so skipping the dict values is safe. If alarm support is added later, the `vj` dict values will need dedicated parsing.

## Changes

| File | Change |
|------|--------|
| `src/blueair_api/intermediate_representation_aws.py` | Replace assert with skip-and-log for non-scalar values; add `vj` match case |
| `tests/device_info/mini_restful.json` | New fixture — Mini Restful with active sunrise alarm (reproduces the crash) |
| `tests/test_device_aws.py` | New `MiniRestfulTest` class testing full attribute refresh against the fixture |
| `tests/test_intermediate_representation_aws.py` | New tests for `vj` string values and `vj` dict values (skip behavior) |

## Testing

- 106 tests pass
- ruff clean
- Reproduces the crash without the fix (assert fails on `alarm1` dict value)
- With the fix, refresh completes normally and all other attributes parse correctly
