### PR TITLE
feat: dynamic MQTT sensor and state mapping (Phase 1 of #334)

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -170,6 +170,31 @@ mqtt.disconnect()
 | `on_connect_callback` | `()` | MQTT connection established |
 | `on_disconnect_callback` | `()` | MQTT connection lost |
 
+## Dynamic Sensor and State Mapping
+
+The `DeviceAws` class exposes two helpers that consumers (e.g. `ha_blueair`)
+can call from the MQTT callbacks to apply incoming data to device attributes
+without hardcoding sensor names:
+
+- `device.apply_sensor_data(sensors)` — call from `on_sensor_data`.  Maps
+  each MQTT slug via `MQTT_SENSOR_FIELD_MAP` to a `DeviceAws` attribute and
+  casts the value to `int`.  Unknown slugs land in `device.extra_sensors`.
+- `device.apply_state_change(state)` — call from `on_state_change`.  Maps
+  each shadow field via `SHADOW_FIELD_MAP` to a `DeviceAws` attribute, with
+  humidifier fan-speed remapping (11/37/64 → 1/2/3) applied automatically.
+
+The current maps (in `device_aws.py`) cover all sensors and shadow fields
+observed across the supported device fixtures (purifiers, humidifiers,
+combos, Mini Restful).  Adding a new device that publishes a new slug
+requires only a one-line entry in the relevant map plus the matching
+`DeviceAws` attribute — no changes to the MQTT plumbing.
+
+The `device.mqtt_sensor_slugs` list, parsed from
+`configuration.ds.rt5s.sn` during `refresh()`, captures the exact set of
+sensor names the device declares it will publish on the 5-second topic.
+This enables future schema-driven entity discovery without further library
+changes.
+
 ## Reconnection & Token Refresh
 
 AWS IoT Custom Authorizer tokens expire after 24 hours. When a token

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -25,6 +25,7 @@ MQTT_SENSOR_FIELD_MAP: dict[str, str] = {
     "t": "temperature",
     "h": "humidity",
     "fsp0": "fan_speed_0",
+    "rssi": "rssi",
 }
 
 # Mapping from shadow state field (as sent on $aws/things/<id>/shadow/...)
@@ -54,6 +55,13 @@ SHADOW_FIELD_MAP: dict[str, str] = {
     "apsubmode": "ap_sub_mode",
     "fsp0": "fan_speed_0",
     "tu": "temperature_unit",
+    # Mini Restful sunrise / timer fields.
+    "nlstepless": "night_light_brightness",
+    "timstate": "timer_state",
+    "timl": "timer_level",
+    "timts": "timer_start_timestamp",
+    "timdur": "timer_duration",
+    "hourformat": "hour_format",
 }
 
 @dataclass(slots=True)
@@ -129,6 +137,18 @@ class DeviceAws(CallbacksMixin):
     temperature_unit: AttributeType[int] = None # api value of 1 is celcius
     hw: AttributeType[str] = None # hardware identifier from configuration.di.hw
 
+    # MQTT-only first-class sensor (signal strength, dBm).
+    rssi: AttributeType[int] = None
+
+    # Mini Restful sunrise / timer fields (also present on humidifiers
+    # like H35i for the sleep timer).
+    night_light_brightness: AttributeType[int] = None  # nlstepless, 0-100
+    timer_state: AttributeType[int] = None  # timstate, 0=off 1=running
+    timer_level: AttributeType[int] = None  # timl
+    timer_start_timestamp: AttributeType[int] = None  # timts, unix epoch
+    timer_duration: AttributeType[int] = None  # timdur, seconds
+    hour_format: AttributeType[bool] = None  # hourformat, False=12h True=24h
+
     mqtt_sensor_slugs: list[str] = field(default_factory=list, repr=False, init=False)
     extra_sensors: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
@@ -159,9 +179,21 @@ class DeviceAws(CallbacksMixin):
         ds = ir.parse_json(ir.Sensor, raw_ds)
         dc = ir.parse_json(ir.Control, ir.query_json(self.raw_info, "configuration.dc"))
 
-        # Store the list of MQTT sensor slugs from the 5-second polling topic.
-        rt5s_raw = raw_ds.get("rt5s", {}) if isinstance(raw_ds, dict) else {}
-        self.mqtt_sensor_slugs = list(rt5s_raw.get("sn", []))
+        # Store the list of MQTT sensor slugs from the 5-second polling
+        # topic.  Defensive against malformed schemas: rt5s missing,
+        # rt5s.sn null, or wrong types all degrade to an empty list so
+        # apply_sensor_data and is_implemented checks stay correct.
+        rt5s_raw = raw_ds.get("rt5s") if isinstance(raw_ds, dict) else None
+        sn = rt5s_raw.get("sn") if isinstance(rt5s_raw, dict) else None
+        self.mqtt_sensor_slugs = (
+            [str(s) for s in sn] if isinstance(sn, list) else []
+        )
+        # Log once per refresh so the expected MQTT slug set is visible
+        # in user-supplied debug logs.
+        _LOGGER.debug(
+            "Device %s declares MQTT 5s sensor slugs: %s",
+            self.uuid, self.mqtt_sensor_slugs
+        )
 
         # Auto-populate dc from state keys the device reports but aren't
         # declared in the dc schema.  Some devices (e.g. H38i, H76i,
@@ -188,6 +220,7 @@ class DeviceAws(CallbacksMixin):
         self.temperature = sensor_data_safe_get("t")
         self.humidity = sensor_data_safe_get("h")
         self.fan_speed_0 = sensor_data_safe_get("fsp0")
+        self.rssi = sensor_data_safe_get("rssi")
 
         states = ir.SensorPack(self.raw_info["states"]).to_latest_value()
 
@@ -242,6 +275,14 @@ class DeviceAws(CallbacksMixin):
             self.fan_speed_0 = states_safe_get("fsp0")
         self.temperature_unit = states_safe_get("tu")
 
+        # Mini Restful sunrise / timer fields.
+        self.night_light_brightness = states_safe_get("nlstepless")
+        self.timer_state = states_safe_get("timstate")
+        self.timer_level = states_safe_get("timl")
+        self.timer_start_timestamp = states_safe_get("timts")
+        self.timer_duration = states_safe_get("timdur")
+        self.hour_format = states_safe_get("hourformat")
+
         self.publish_updates()
         _LOGGER.debug(f"refreshed blueair device aws: {self}")
 
@@ -249,26 +290,74 @@ class DeviceAws(CallbacksMixin):
         """Apply MQTT sensor data to device attributes.
 
         Maps MQTT sensor slugs to DeviceAws attribute names using
-        MQTT_SENSOR_FIELD_MAP. Unknown fields are stored in extra_sensors.
+        MQTT_SENSOR_FIELD_MAP. Unknown fields are stored in extra_sensors
+        (logged once per slug at debug level so unmapped fields can be
+        diagnosed from logs).
+
+        Per-slug failures are caught and logged so a single bad value
+        does not drop the rest of the batch.
         """
         for slug, value in sensors.items():
             attr = MQTT_SENSOR_FIELD_MAP.get(slug)
-            if attr is not None:
-                setattr(self, attr, int(value))
-            else:
+            if attr is None:
+                if slug not in self.extra_sensors:
+                    _LOGGER.debug(
+                        "MQTT sensor %r not in MQTT_SENSOR_FIELD_MAP; "
+                        "storing in extra_sensors (value=%r)", slug, value
+                    )
                 self.extra_sensors[slug] = value
+                continue
+            try:
+                setattr(self, attr, int(value))
+            except (TypeError, ValueError):
+                _LOGGER.warning(
+                    "MQTT sensor %r (-> %s) has unexpected value %r; "
+                    "skipping this update", slug, attr, value
+                )
+            except AttributeError:
+                # slots=True: attr in map but not declared on dataclass.
+                _LOGGER.error(
+                    "MQTT_SENSOR_FIELD_MAP maps %r to %r but DeviceAws "
+                    "has no such attribute; this is a library bug",
+                    slug, attr
+                )
 
     def apply_state_change(self, state: dict[str, Any]) -> None:
         """Apply MQTT shadow state update to device attributes.
 
         Maps shadow field names to DeviceAws attribute names using
         SHADOW_FIELD_MAP. Applies humidifier fan speed remapping.
+
+        Unmapped fields and per-field failures are logged so behavior
+        can be diagnosed from logs alone.
         """
         for shadow_field, value in state.items():
             attr = SHADOW_FIELD_MAP.get(shadow_field)
-            if attr is not None and hasattr(self, attr):
+            if attr is None:
+                _LOGGER.debug(
+                    "Shadow field %r not in SHADOW_FIELD_MAP; ignoring "
+                    "(value=%r)", shadow_field, value
+                )
+                continue
+            if not hasattr(self, attr):
+                # slots=True: attr in map but not declared on dataclass.
+                _LOGGER.error(
+                    "SHADOW_FIELD_MAP maps %r to %r but DeviceAws has "
+                    "no such attribute; this is a library bug",
+                    shadow_field, attr
+                )
+                continue
+            try:
                 setattr(self, attr, value)
+            except AttributeError:
+                _LOGGER.error(
+                    "Failed to set DeviceAws.%s = %r from shadow field %r",
+                    attr, value, shadow_field
+                )
+
         # Apply humidifier fan speed remapping (same as refresh).
+        # Only remap if the loop above actually set fan_speed to a known
+        # raw value; guard against non-int payloads landing on the attr.
         if "fanspeed" in state and self._is_humidifier:
             if self.fan_speed == 11:
                 self.fan_speed = 1
@@ -400,6 +489,24 @@ class DeviceAws(CallbacksMixin):
     async def set_fan_speed_0(self, value: int):
         self.fan_speed_0 = value
         await self.api.set_device_info(self.uuid, "fsp0", "v", value)
+        self.publish_updates()
+
+    async def set_night_light_brightness(self, value: int):
+        """Set the sunrise / night light stepless brightness (0-100)."""
+        self.night_light_brightness = value
+        await self.api.set_device_info(self.uuid, "nlstepless", "v", value)
+        self.publish_updates()
+
+    async def set_timer_duration(self, value: int):
+        """Set the sleep / off timer duration in seconds."""
+        self.timer_duration = value
+        await self.api.set_device_info(self.uuid, "timdur", "v", value)
+        self.publish_updates()
+
+    async def set_hour_format(self, value: bool):
+        """Set the clock display: False = 12-hour, True = 24-hour."""
+        self.hour_format = value
+        await self.api.set_device_info(self.uuid, "hourformat", "vb", value)
         self.publish_updates()
 
     @property

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -14,6 +14,48 @@ _LOGGER = getLogger(__name__)
 
 type AttributeType[T] = T | None
 
+# Mapping from MQTT sensor slug (as sent on d/<id>/s/5s topic) to DeviceAws
+# attribute name.  Values arrive as floats from SenML and are cast to int.
+MQTT_SENSOR_FIELD_MAP: dict[str, str] = {
+    "pm1": "pm1",
+    "pm2_5": "pm2_5",
+    "pm10": "pm10",
+    "tVOC": "total_voc",
+    "voc": "voc",
+    "t": "temperature",
+    "h": "humidity",
+    "fsp0": "fan_speed_0",
+}
+
+# Mapping from shadow state field (as sent on $aws/things/<id>/shadow/...)
+# to DeviceAws attribute name.
+SHADOW_FIELD_MAP: dict[str, str] = {
+    "standby": "standby",
+    "nightmode": "night_mode",
+    "germshield": "germ_shield",
+    "brightness": "brightness",
+    "nlbrightness": "mood_brightness",
+    "childlock": "child_lock",
+    "wlevel": "water_level",
+    "fanspeed": "fan_speed",
+    "automode": "fan_auto_mode",
+    "filterusage": "filter_usage_percentage",
+    "ywrmusage": "water_refresher_usage_percentage",
+    "wickusage": "wick_usage_percentage",
+    "wickdrys": "wick_dry_mode",
+    "autorh": "auto_regulated_humidity",
+    "wshortage": "water_shortage",
+    "mainmode": "main_mode",
+    "heattemp": "heat_temp",
+    "heatsubmode": "heat_sub_mode",
+    "heatfs": "heat_fan_speed",
+    "coolsubmode": "cool_sub_mode",
+    "coolfs": "cool_fan_speed",
+    "apsubmode": "ap_sub_mode",
+    "fsp0": "fan_speed_0",
+    "tu": "temperature_unit",
+}
+
 @dataclass(slots=True)
 class DeviceAws(CallbacksMixin):
     @classmethod
@@ -87,6 +129,9 @@ class DeviceAws(CallbacksMixin):
     temperature_unit: AttributeType[int] = None # api value of 1 is celcius
     hw: AttributeType[str] = None # hardware identifier from configuration.di.hw
 
+    mqtt_sensor_slugs: list[str] = field(default_factory=list, repr=False, init=False)
+    extra_sensors: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
+
     async def refresh(self):
         _LOGGER.debug(f"refreshing blueair device aws: {self}")
         self.raw_info = await self.api.device_info(self.name_api, self.uuid)
@@ -110,8 +155,14 @@ class DeviceAws(CallbacksMixin):
         self.sku = info_safe_get("configuration.di.sku")
         self.hw = info_safe_get("configuration.di.hw")
 
-        ds = ir.parse_json(ir.Sensor, ir.query_json(self.raw_info, "configuration.ds"))
+        raw_ds = ir.query_json(self.raw_info, "configuration.ds")
+        ds = ir.parse_json(ir.Sensor, raw_ds)
         dc = ir.parse_json(ir.Control, ir.query_json(self.raw_info, "configuration.dc"))
+
+        # Store the list of MQTT sensor slugs from the 5-second polling topic.
+        rt5s_raw = raw_ds.get("rt5s", {}) if isinstance(raw_ds, dict) else {}
+        self.mqtt_sensor_slugs = list(rt5s_raw.get("sn", []))
+
         # Auto-populate dc from state keys the device reports but aren't
         # declared in the dc schema.  Some devices (e.g. H38i, H76i,
         # Mini Restful) have an incomplete dc yet still publish the
@@ -193,6 +244,38 @@ class DeviceAws(CallbacksMixin):
 
         self.publish_updates()
         _LOGGER.debug(f"refreshed blueair device aws: {self}")
+
+    def apply_sensor_data(self, sensors: dict[str, float]) -> None:
+        """Apply MQTT sensor data to device attributes.
+
+        Maps MQTT sensor slugs to DeviceAws attribute names using
+        MQTT_SENSOR_FIELD_MAP. Unknown fields are stored in extra_sensors.
+        """
+        for slug, value in sensors.items():
+            attr = MQTT_SENSOR_FIELD_MAP.get(slug)
+            if attr is not None:
+                setattr(self, attr, int(value))
+            else:
+                self.extra_sensors[slug] = value
+
+    def apply_state_change(self, state: dict[str, Any]) -> None:
+        """Apply MQTT shadow state update to device attributes.
+
+        Maps shadow field names to DeviceAws attribute names using
+        SHADOW_FIELD_MAP. Applies humidifier fan speed remapping.
+        """
+        for shadow_field, value in state.items():
+            attr = SHADOW_FIELD_MAP.get(shadow_field)
+            if attr is not None and hasattr(self, attr):
+                setattr(self, attr, value)
+        # Apply humidifier fan speed remapping (same as refresh).
+        if "fanspeed" in state and self._is_humidifier:
+            if self.fan_speed == 11:
+                self.fan_speed = 1
+            elif self.fan_speed == 37:
+                self.fan_speed = 2
+            elif self.fan_speed == 64:
+                self.fan_speed = 3
 
     async def set_brightness(self, value: int):
         self.brightness = value

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -1129,3 +1129,133 @@ class ModelNameTest(DeviceAwsTestBase):
         """Missing SKU (NotImplemented) falls back gracefully."""
         await self.device.refresh()
         assert UNKNOWN_MODEL in self.device.model_name
+
+
+class MqttSensorSlugsTest(DeviceAwsTestBase):
+    """Tests that mqtt_sensor_slugs is populated from rt5s.sn."""
+
+    async def test_slugs_populated_from_rt5s(self):
+        ir.query_json(self.device_info_helper.info, "configuration.ds")["rt5s"] = {
+            "sn": ["pm2_5", "fsp0", "rssi", "pm1", "pm10"],
+            "tn": "d/fake-uuid/s/5s", "ttl": 1200,
+            "n": "rt5s", "ot": "RT5s", "e": False, "i": 5000, "fe": True,
+        }
+        await self.device.refresh()
+        assert self.device.mqtt_sensor_slugs == ["pm2_5", "fsp0", "rssi", "pm1", "pm10"]
+
+    async def test_slugs_empty_when_no_rt5s(self):
+        await self.device.refresh()
+        assert self.device.mqtt_sensor_slugs == []
+
+    async def test_humidifier_slugs(self):
+        ir.query_json(self.device_info_helper.info, "configuration.ds")["rt5s"] = {
+            "sn": ["t", "h", "rssi"],
+            "tn": "d/fake-uuid/s/5s", "ttl": -1,
+            "n": "rt5s", "ot": "RT5s", "e": False, "i": 0, "fe": True,
+        }
+        await self.device.refresh()
+        assert self.device.mqtt_sensor_slugs == ["t", "h", "rssi"]
+
+
+class ApplySensorDataTest(DeviceAwsTestBase):
+    """Tests for DeviceAws.apply_sensor_data()."""
+
+    async def test_known_fields_mapped(self):
+        await self.device.refresh()
+        self.device.apply_sensor_data({
+            "pm1": 5.0, "pm2_5": 12.0, "pm10": 20.0, "fsp0": 37.0,
+        })
+        assert self.device.pm1 == 5
+        assert self.device.pm2_5 == 12
+        assert self.device.pm10 == 20
+        assert self.device.fan_speed_0 == 37
+
+    async def test_renamed_fields_mapped(self):
+        await self.device.refresh()
+        self.device.apply_sensor_data({"t": 22.0, "h": 55.0, "tVOC": 100.0, "voc": 42.0})
+        assert self.device.temperature == 22
+        assert self.device.humidity == 55
+        assert self.device.total_voc == 100
+        assert self.device.voc == 42
+
+    async def test_unknown_fields_go_to_extra_sensors(self):
+        await self.device.refresh()
+        self.device.apply_sensor_data({"rssi": -45.0, "pm2_5": 3.0})
+        assert self.device.pm2_5 == 3
+        assert self.device.extra_sensors == {"rssi": -45.0}
+
+    async def test_empty_sensors(self):
+        await self.device.refresh()
+        self.device.apply_sensor_data({})
+        assert self.device.extra_sensors == {}
+
+
+class ApplyStateChangeTest(DeviceAwsTestBase):
+    """Tests for DeviceAws.apply_state_change()."""
+
+    async def test_known_state_fields(self):
+        await self.device.refresh()
+        self.device.apply_state_change({
+            "fanspeed": 51,
+            "standby": False,
+            "brightness": 64,
+        })
+        assert self.device.fan_speed == 51
+        assert self.device.standby is False
+        assert self.device.brightness == 64
+
+    async def test_all_shadow_fields(self):
+        await self.device.refresh()
+        self.device.apply_state_change({
+            "nightmode": True,
+            "germshield": True,
+            "childlock": True,
+            "automode": True,
+            "filterusage": 42,
+            "nlbrightness": 80,
+            "wickusage": 30,
+            "wickdrys": True,
+            "autorh": 50,
+            "wshortage": False,
+            "wlevel": 3,
+            "fsp0": 64,
+            "tu": 1,
+        })
+        assert self.device.night_mode is True
+        assert self.device.germ_shield is True
+        assert self.device.child_lock is True
+        assert self.device.fan_auto_mode is True
+        assert self.device.filter_usage_percentage == 42
+        assert self.device.mood_brightness == 80
+        assert self.device.wick_usage_percentage == 30
+        assert self.device.wick_dry_mode is True
+        assert self.device.auto_regulated_humidity == 50
+        assert self.device.water_shortage is False
+        assert self.device.water_level == 3
+        assert self.device.fan_speed_0 == 64
+        assert self.device.temperature_unit == 1
+
+    async def test_humidifier_fan_speed_remapped(self):
+        """Humidifier devices remap raw fan speed 11/37/64 → 1/2/3."""
+        ir.query_json(self.device_info_helper.info, "configuration.di")["hw"] = "hum2_l"
+        await self.device.refresh()
+
+        self.device.apply_state_change({"fanspeed": 11})
+        assert self.device.fan_speed == 1
+
+        self.device.apply_state_change({"fanspeed": 37})
+        assert self.device.fan_speed == 2
+
+        self.device.apply_state_change({"fanspeed": 64})
+        assert self.device.fan_speed == 3
+
+    async def test_non_humidifier_fan_speed_not_remapped(self):
+        ir.query_json(self.device_info_helper.info, "configuration.di")["hw"] = "nb_h_1.0"
+        await self.device.refresh()
+        self.device.apply_state_change({"fanspeed": 37})
+        assert self.device.fan_speed == 37
+
+    async def test_unknown_shadow_fields_ignored(self):
+        await self.device.refresh()
+        self.device.apply_state_change({"unknownfield": 99, "brightness": 50})
+        assert self.device.brightness == 50

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -398,6 +398,13 @@ class EmptyDeviceAwsTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is NotImplemented
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state is NotImplemented
+            assert device.timer_level is NotImplemented
+            assert device.timer_start_timestamp is NotImplemented
+            assert device.timer_duration is NotImplemented
+            assert device.hour_format is NotImplemented
 
 
 class H35iTest(DeviceAwsTestBase):
@@ -457,6 +464,13 @@ class H35iTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 7200
+            assert device.hour_format is NotImplemented
 
 
 class H38iTest(DeviceAwsTestBase):
@@ -516,6 +530,13 @@ class H38iTest(DeviceAwsTestBase):
             assert device.mood_brightness == 0
             assert device.water_refresher_usage_percentage == 0
             assert device.water_level == 0
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 7200
+            assert device.hour_format is NotImplemented
 
 
 class H76iTest(DeviceAwsTestBase):
@@ -575,6 +596,13 @@ class H76iTest(DeviceAwsTestBase):
             assert device.mood_brightness == 0
             assert device.water_refresher_usage_percentage == 0
             assert device.water_level == 50
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 7200
+            assert device.hour_format is NotImplemented
 
 
 class Max311iTest(DeviceAwsTestBase):
@@ -633,6 +661,13 @@ class Max311iTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state is NotImplemented
+            assert device.timer_level is NotImplemented
+            assert device.timer_start_timestamp is NotImplemented
+            assert device.timer_duration is NotImplemented
+            assert device.hour_format is NotImplemented
 
 
 class T10iTest(DeviceAwsTestBase):
@@ -692,6 +727,13 @@ class T10iTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 3600
+            assert device.hour_format is NotImplemented
 
 
 class Protect7470iTest(DeviceAwsTestBase):
@@ -753,6 +795,13 @@ class Protect7470iTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state is NotImplemented
+            assert device.timer_level is NotImplemented
+            assert device.timer_start_timestamp is NotImplemented
+            assert device.timer_duration is NotImplemented
+            assert device.hour_format is NotImplemented
 
 
 class Max211iTest(DeviceAwsTestBase):
@@ -812,6 +861,13 @@ class Max211iTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state is NotImplemented
+            assert device.timer_level is NotImplemented
+            assert device.timer_start_timestamp is NotImplemented
+            assert device.timer_duration is NotImplemented
+            assert device.hour_format is NotImplemented
 
 
 class PetAirProTest(DeviceAwsTestBase):
@@ -871,6 +927,13 @@ class PetAirProTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 7200
+            assert device.hour_format is NotImplemented
 
 
 class TwoInOneTest(DeviceAwsTestBase):
@@ -930,6 +993,13 @@ class TwoInOneTest(DeviceAwsTestBase):
             assert device.mood_brightness == 0
             assert device.water_refresher_usage_percentage == 0
             assert device.water_level == 75.0
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 1800
+            assert device.hour_format is NotImplemented
 
 
 class NullValueTest(DeviceAwsTestBase):
@@ -989,6 +1059,13 @@ class NullValueTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness == 0
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 7200
+            assert device.hour_format is False
 
 
 class MiniRestfulAlarmTest(DeviceAwsTestBase):
@@ -1051,6 +1128,13 @@ class MiniRestfulAlarmTest(DeviceAwsTestBase):
             assert device.mood_brightness is NotImplemented
             assert device.water_refresher_usage_percentage is NotImplemented
             assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness == 0
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 7200
+            assert device.hour_format is False
 
 
 class OnlineStateTest(DeviceAwsTestBase):
@@ -1156,6 +1240,39 @@ class MqttSensorSlugsTest(DeviceAwsTestBase):
         await self.device.refresh()
         assert self.device.mqtt_sensor_slugs == ["t", "h", "rssi"]
 
+    async def test_slugs_robust_to_malformed_rt5s(self):
+        """Defensive parsing: if rt5s.sn is missing or wrong-shaped,
+        mqtt_sensor_slugs degrades to an empty list rather than
+        crashing the refresh pipeline.
+
+        Note: cases where rt5s itself is malformed enough to fail the
+        ds-schema parse upstream (rt5s = null, rt5s = []) are handled
+        by intermediate_representation_aws.parse_json — not exercised
+        here.  This test covers the path where parse_json succeeds but
+        the rt5s.sn array is missing or the wrong type.
+        """
+        ds = ir.query_json(self.device_info_helper.info, "configuration.ds")
+        well_formed_envelope = {
+            "tn": "d/fake-uuid/s/5s", "ttl": -1,
+            "n": "rt5s", "ot": "RT5s", "e": False, "i": 0, "fe": True,
+        }
+
+        # rt5s present but missing 'sn' entirely
+        ds["rt5s"] = dict(well_formed_envelope)
+        await self.device.refresh()
+        assert self.device.mqtt_sensor_slugs == []
+
+        # rt5s.sn is a string instead of a list
+        ds["rt5s"] = {**well_formed_envelope, "sn": "rssi"}
+        await self.device.refresh()
+        assert self.device.mqtt_sensor_slugs == []
+
+        # rt5s.sn contains non-string entries — coerce to str so the
+        # list-of-str invariant holds for downstream code.
+        ds["rt5s"] = {**well_formed_envelope, "sn": ["rssi", 42, None]}
+        await self.device.refresh()
+        assert self.device.mqtt_sensor_slugs == ["rssi", "42", "None"]
+
 
 class ApplySensorDataTest(DeviceAwsTestBase):
     """Tests for DeviceAws.apply_sensor_data()."""
@@ -1180,14 +1297,33 @@ class ApplySensorDataTest(DeviceAwsTestBase):
 
     async def test_unknown_fields_go_to_extra_sensors(self):
         await self.device.refresh()
-        self.device.apply_sensor_data({"rssi": -45.0, "pm2_5": 3.0})
+        # Use a slug not in MQTT_SENSOR_FIELD_MAP (rssi is now first-class).
+        self.device.apply_sensor_data({"unknownsensor": 99.5, "pm2_5": 3.0})
         assert self.device.pm2_5 == 3
-        assert self.device.extra_sensors == {"rssi": -45.0}
+        assert self.device.extra_sensors == {"unknownsensor": 99.5}
+
+    async def test_rssi_is_first_class(self):
+        """rssi is mapped to device.rssi, not extra_sensors."""
+        await self.device.refresh()
+        self.device.apply_sensor_data({"rssi": -45.0})
+        assert self.device.rssi == -45
+        assert "rssi" not in self.device.extra_sensors
 
     async def test_empty_sensors(self):
         await self.device.refresh()
         self.device.apply_sensor_data({})
         assert self.device.extra_sensors == {}
+
+    async def test_bad_value_logs_and_skips(self):
+        """Non-numeric sensor value is logged and the rest of the batch lands."""
+        await self.device.refresh()
+        with self.assertLogs("blueair_api.device_aws", level="WARNING") as cm:
+            self.device.apply_sensor_data(
+                {"pm2_5": "not-a-number", "pm1": 5.0}
+            )
+        # Bad value skipped, good value applied.
+        assert self.device.pm1 == 5
+        assert any("pm2_5" in m for m in cm.output)
 
 
 class ApplyStateChangeTest(DeviceAwsTestBase):
@@ -1259,3 +1395,106 @@ class ApplyStateChangeTest(DeviceAwsTestBase):
         await self.device.refresh()
         self.device.apply_state_change({"unknownfield": 99, "brightness": 50})
         assert self.device.brightness == 50
+
+    async def test_shadow_map_typo_logs_error_and_continues(self):
+        """A SHADOW_FIELD_MAP entry pointing at a non-existent attribute
+        logs ERROR but the rest of the batch still applies.
+
+        Guards against typos in the map (e.g. 'brightness' -> 'birghtness')
+        from silently dropping otherwise-valid updates.
+        """
+        from blueair_api import device_aws as device_aws_module
+        await self.device.refresh()
+        with (
+            mock.patch.dict(
+                device_aws_module.SHADOW_FIELD_MAP,
+                {"bogus": "no_such_attr"},
+            ),
+            self.assertLogs("blueair_api.device_aws", level="ERROR") as cm,
+        ):
+            self.device.apply_state_change({"bogus": 1, "brightness": 50})
+        assert self.device.brightness == 50
+        assert any("no_such_attr" in msg for msg in cm.output)
+
+
+class MiniRestfulShadowTest(DeviceAwsTestBase):
+    """Tests for Mini Restful sunrise / timer fields via shadow updates."""
+
+    async def test_sunrise_and_clock_via_shadow(self):
+        """nlstepless and hourformat propagate via apply_state_change."""
+        await self.device.refresh()
+        self.device.apply_state_change({"nlstepless": 75, "hourformat": True})
+        assert self.device.night_light_brightness == 75
+        assert self.device.hour_format is True
+
+    async def test_timer_via_shadow(self):
+        """timstate / timl / timts / timdur propagate via apply_state_change."""
+        await self.device.refresh()
+        self.device.apply_state_change({
+            "timstate": 1,
+            "timl": 7200,
+            "timts": 1773716704,
+            "timdur": 7200,
+        })
+        assert self.device.timer_state == 1
+        assert self.device.timer_level == 7200
+        assert self.device.timer_start_timestamp == 1773716704
+        assert self.device.timer_duration == 7200
+
+    async def test_refresh_populates_timer_fields(self):
+        """Loading the mini_restful fixture populates timer/sunrise attrs from REST."""
+        with open(resources.files().joinpath('device_info/mini_restful.json')) as sample_file:
+            info = json.load(sample_file)
+        self.device_info_helper.info.update(info)
+        await self.device.refresh()
+        assert self.device.night_light_brightness == 0
+        assert self.device.timer_state == 0
+        assert self.device.timer_level == 0
+        assert self.device.timer_start_timestamp == 0
+        assert self.device.timer_duration == 7200
+        assert self.device.hour_format is False
+
+
+class MiniRestfulSetterTest(DeviceAwsTestBase):
+    """Tests for the new sunrise / timer / clock setters."""
+
+    def setUp(self):
+        super().setUp()
+        # Populate dc so refresh() will read the states back.
+        fake = {"n": "n", "v": 0}
+        ir.query_json(self.device_info_helper.info, "configuration.dc").update({
+            "nlstepless": fake,
+            "timdur": fake,
+            "hourformat": fake,
+        })
+
+    async def test_set_night_light_brightness(self):
+        self.device.night_light_brightness = None
+        await self.device.set_night_light_brightness(75)
+        assert self.device.night_light_brightness == 75
+
+        await self.device.set_night_light_brightness(50)
+        self.device.night_light_brightness = None
+        await self.device.refresh()
+        assert self.device.night_light_brightness == 50
+
+    async def test_set_timer_duration(self):
+        self.device.timer_duration = None
+        await self.device.set_timer_duration(3600)
+        assert self.device.timer_duration == 3600
+
+        await self.device.set_timer_duration(7200)
+        self.device.timer_duration = None
+        await self.device.refresh()
+        assert self.device.timer_duration == 7200
+
+    async def test_set_hour_format(self):
+        self.device.hour_format = None
+        await self.device.set_hour_format(True)
+        assert self.device.hour_format is True
+
+        await self.device.set_hour_format(False)
+        self.device.hour_format = None
+        await self.device.refresh()
+        assert self.device.hour_format is False
+


### PR DESCRIPTION
Phase 1 of [dahlb/ha_blueair#334](https://github.com/dahlb/ha_blueair/issues/334).
Adds dynamic MQTT sensor and shadow-state field mapping to `DeviceAws`, plus
new Mini Restful sunrise / timer / clock attributes.

## Problem

Three issues with how MQTT data was reaching `DeviceAws`:

1. **Humidifier sensors were silently dropped.** The H35i / H38i / H76i
   publish `t` (temperature), `h` (humidity), and `rssi` over MQTT, but
   the integration's hardcoded `if "pm1" in sensors / if "pm2_5" in
   sensors / ...` chain only knew about purifier fields. Those values
   went to `/dev/null`.

2. **Shadow updates (state changes) were never wired through.** The
   library exposes an `on_state_change` callback that receives the full
   reported state of the device whenever the firmware pushes an update
   (fan speed changes, brightness changes, etc.), but nothing applied
   those values to `DeviceAws` attributes — they only landed via the
   5-minute REST poll.

3. **Mini Restful's sunrise / timer / clock fields had no place to live.**
   `nlstepless`, `timstate`, `timl`, `timts`, `timdur`, `hourformat` are
   declared in the device schema and emitted by the firmware, but
   `DeviceAws` had no attributes for them.

## Solution

### `MQTT_SENSOR_FIELD_MAP` and `SHADOW_FIELD_MAP`

Two module-level dicts in `device_aws.py` translate raw cloud-API slug
names to Pythonic `DeviceAws` attribute names:

```python
MQTT_SENSOR_FIELD_MAP = {
    "pm1": "pm1", "pm2_5": "pm2_5", "pm10": "pm10",
    "tVOC": "total_voc", "voc": "voc",
    "t": "temperature", "h": "humidity",
    "fsp0": "fan_speed_0", "rssi": "rssi",
}

SHADOW_FIELD_MAP = {
    # 25 existing slugs covering all current humidifier / purifier /
    # combo state fields, plus the Mini Restful additions:
    "nlstepless": "night_light_brightness",
    "timstate": "timer_state",
    "timl": "timer_level",
    "timts": "timer_start_timestamp",
    "timdur": "timer_duration",
    "hourformat": "hour_format",
}
```

### Two new public methods on `DeviceAws`

```python
def apply_sensor_data(self, sensors: dict[str, float]) -> None:
    """Apply MQTT 5s sensor batch.  Casts each value to int via
    MQTT_SENSOR_FIELD_MAP.  Unknown slugs land in extra_sensors with
    a one-time DEBUG log for diagnosis."""

def apply_state_change(self, state: dict[str, Any]) -> None:
    """Apply MQTT shadow reported-state batch.  Translates each slug
    via SHADOW_FIELD_MAP.  Includes humidifier fan-speed remapping
    (11/37/64 → 1/2/3) consistent with refresh()."""
```

`ha_blueair` will call these from its MQTT callbacks (the ha_blueair PR
is the companion to this one).

### 7 new `DeviceAws` attributes

| MQTT slug | Attribute | Notes |
|---|---|---|
| `rssi` | `rssi` | Promoted from `extra_sensors` to first-class; declared by every supported device |
| `nlstepless` | `night_light_brightness` | 0-100, Mini Restful sunrise stepless brightness |
| `timstate` | `timer_state` | 0=off, 1=running |
| `timl` | `timer_level` | Timer level/target (semantics still being characterised) |
| `timts` | `timer_start_timestamp` | Unix epoch start |
| `timdur` | `timer_duration` | Seconds, default 7200 |
| `hourformat` | `hour_format` | False=12h, True=24h, Mini Restful |

All seven fields are populated from REST `states[]` during `refresh()`
and from MQTT shadow updates via `apply_state_change()`. Three new
async setters (`set_night_light_brightness`, `set_timer_duration`,
`set_hour_format`) hit the existing `set_device_info` API.

### Diagnostic logging

Built for HACS users who can only share log files:

- One-line schema announcement per `refresh()`:
  `DEBUG Device <uuid> declares MQTT 5s sensor slugs: [...]`
- Per-slug DEBUG when a new unknown slug lands in `extra_sensors`
- WARNING when a sensor value fails `int()` cast (e.g. cloud returns
  `"NaN"`); the rest of the batch is still applied
- ERROR when a map entry points at a non-existent `DeviceAws`
  attribute ("this is a library bug") — guards against typos in the
  maps

### Defensive parsing

`mqtt_sensor_slugs` is parsed from `configuration.ds.rt5s.sn` with
guards against malformed schemas (missing `sn`, wrong type, non-string
entries). Degrades to an empty list rather than crashing the refresh.

## Testing

| Layer | Tests |
|---|---|
| Unit | 128 tests, all green |
| Lint | `ruff check src/ tests/` clean |
| Types | `mypy src/blueair_api/device_aws.py` clean |
| Device fixtures | All 12 (purifiers, humidifiers, combo, Mini Restful) updated with assertions for new attrs via the existing `assert_fully_checked` guard |
| Failure paths | New tests for bad value casts, typo'd map entries, malformed `rt5s.sn` |

Live-tested for 24 hours on a Blue Max 211i:

- **1,244 minutes of continuous sensor data, 0 gaps**
- **20 hourly reconnects, 100% successful**
- **0 token errors, 0 callback errors**
- 14,840 MQTT sensor messages processed

## Compatibility

- No public API removed.
- New attributes default to `None` / `NotImplemented` for devices that
  don't declare them; existing tests confirm humidifier-only or
  Mini-Restful-only fields stay `NotImplemented` on Max 211i, etc.
- `extra_sensors` retained for genuinely-unknown future slugs (one was
  observed: `cfv`/`mfv`/`ofv` firmware version numbers; flagged as a
  separate small follow-up issue).

## Version

Bumps `pyproject.toml` to `1.51.0` (minor — new feature, no breaking
change).

## Files

- `src/blueair_api/device_aws.py` (+192)
- `tests/test_device_aws.py` (+369)
- `docs/mqtt.md` (+25) — new "Dynamic Sensor and State Mapping" section
- `pyproject.toml` (+1 -1)

## Companion PR

Phase 2 of #334 lives in
[philjn/ha_blueair `feature/dynamic-mqtt-sensors`](https://github.com/philjn/ha_blueair/tree/feature/dynamic-mqtt-sensors)
— will be opened against `dahlb/ha_blueair` once this PR releases.

## Follow-ups (out of scope)

- **Phase 3** — schema-driven entity discovery from
  `configuration.dc`/`da`/`ds`. Issue draft ready.
- **Firmware version slugs** — `cfv`/`mfv`/`ofv` shadow fields could
  feed the existing `firmware` / `mcu_firmware` attributes for instant
  OTA version updates. Cosmetic; will file separately.
- **Mini Restful entity backlog** — read-only timer-state / sunrise-
  brightness sensors and writable `number`/`select` controls. Tracked
  on philjn's side.
- **dahlb/ha_blueair#347** — integration teardown race that logs
  ERROR during reloads. Independent fix in a separate branch.

## Ref

- Closes Phase 1 of #334
