### PR TITLE
chore: harden CI for the Python 3.12 -> 3.14 transition

### DIFF
--- a/.github/workflows/pytestPR.yaml
+++ b/.github/workflows/pytestPR.yaml
@@ -14,8 +14,9 @@ jobs:
   main:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
@@ -34,8 +35,9 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Natural Language :: English",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: MacOS :: MacOS X",
 ]
 keywords = [
@@ -37,3 +39,14 @@ keywords = [
 [project.urls]
 "Homepage" = "https://github.com/dahlb/blueair_api"
 "Bug Tracker" = "https://github.com/dahlb/blueair_api/issues"
+
+[tool.pytest.ini_options]
+# Surface latent NotImplemented / int(x or 0) / similar bugs while
+# they are still deprecation warnings, before they become hard
+# TypeErrors. bool(NotImplemented) is the canonical example:
+# emitted DeprecationWarning since 3.9, raises TypeError on 3.14+.
+# Treating DeprecationWarning as an error keeps the test suite
+# honest across the 3.12 -> 3.14 transition.
+filterwarnings = [
+    "error::DeprecationWarning",
+]


### PR DESCRIPTION
## What this changes

Three related additions to the existing `pytestPR.yaml` and
`pyproject.toml`, to surface latent bugs while they are still
deprecation warnings — before they become hard `TypeError`s.

### 1. Python 3.14 in the test + mypy matrix

`pytestPR.yaml`:

```diff
   strategy:
+    fail-fast: false
     matrix:
-      python-version: ["3.13"]
+      python-version: ["3.13", "3.14"]
```

(same change applied to both the `main` and `mypy` jobs)

`fail-fast: false` ensures a 3.14-only regression doesn't mask 3.13
results in the PR check UI.

### 2. `DeprecationWarning → error` during test runs

`pyproject.toml`:

```toml
[tool.pytest.ini_options]
filterwarnings = [
    "error::DeprecationWarning",
]
```

This promotes any `DeprecationWarning` during `pytest tests` to a
hard failure. Catches the patterns Python is removing or has
recently removed:

- `bool(NotImplemented)` — emitted DeprecationWarning since 3.9,
  raises `TypeError` on 3.14+. This is exactly the bug fixed by
  downstream consumers in dahlb/ha_blueair#354 (and the climate.py
  twin in `dahlb/ha_blueair#355). `blueair_api`'s
  own code does not currently use this anti-pattern, but its
  `AttributeType[T] = T | None` sentinel convention makes it
  natural for consumers to write — so an early-warning safety
  net here protects future test contributions.
- `datetime.utcnow()` / `datetime.utcfromtimestamp()` — deprecated
  in 3.12, scheduled for removal in 3.15.
- Various `unittest.assertEqual` aliases.
- pytest plugin API removals.

### 3. Trove classifiers

Bumped `pyproject.toml` classifiers from `Python :: 3.12` only to
include `3.13` and `3.14`, so PyPI metadata matches the CI matrix.

## Validation

- `pytest tests -q` on **Python 3.12.10** with the new
  `filterwarnings` setting: **128 passed in 2.44s** — no warnings
  emitted today.
- `pytest tests -q` on **Python 3.13.13** with the new
  `filterwarnings` setting: **128 passed in 2.73s** — also clean.
- No 3.14 runtime available locally; CI will be the first 3.14
  signal. The point of the matrix add is to learn now (in CI)
  rather than later (in users' homes).

## Why now

Python 3.14 was released Oct 2025. Home Assistant supports 3.14
on its dev branches. `bool(NotImplemented)` raising `TypeError` is
a hard break for any code using the `int(x or 0)` idiom against
fields that return the `NotImplemented` sentinel — a pattern that
`blueair_api`'s `AttributeType[T] = T | None` convention makes
natural for consumers to write. The library itself doesn't carry
this anti-pattern today, but its main consumer (`ha_blueair`) just
fixed one instance in `humidifier.py` (#354) and has three more
in `climate.py` in a follow-up PR. Hardening CI here keeps future
library test contributions on the right side of the deprecation.

## Out of scope

- A structural fix replacing the `NotImplemented` sentinel with a
  proper `Enum` value (which would let mypy/pyright catch these
  statically) — that's a 100+ file change for the whole codebase
  and not appropriate here.
- Bumping `requires-python` past `3.12` — that's a breaking change
  for users on stable HA cores still on 3.12.
- `mypy --strict` — the library uses `NotImplemented` in type
  annotations (`int | None | NotImplemented`), which is a value
  not a type; strict mode would surface that and require a broader
  refactor. Separate issue.

## Risk

Low. Behavior change only on the test runner; no runtime code
touched. If a future test starts emitting a `DeprecationWarning`,
the PR check will fail with a clear stack trace pointing at the
offending line. That's the intended behavior.
