### PR TITLE
feat: expose AP_SUB_MODE_LABELS for Signature/SP4i fan presets

### DIFF
--- a/src/blueair_api/__init__.py
+++ b/src/blueair_api/__init__.py
@@ -4,5 +4,5 @@ from .http_aws_blueair import HttpAwsBlueair
 from .mqtt_aws_blueair import MqttAwsBlueair
 from .util_bootstrap import get_devices, get_aws_devices
 from .device import Device
-from .device_aws import DeviceAws
+from .device_aws import DeviceAws, AP_SUB_MODE_LABELS
 from .sku_map import sku_to_name, model_name_from_sku, UNKNOWN_MODEL

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -64,6 +64,71 @@ SHADOW_FIELD_MAP: dict[str, str] = {
     "hourformat": "hour_format",
 }
 
+# Label map for the `apsubmode` shadow field on Signature-series air
+# purifiers (Blueair Blue Signature SP4i and related models with
+# type_name='blue40', hw='l_blue40'). These devices do NOT expose the
+# legacy `automode` / `nightmode` shadow fields; all preset switching
+# is performed via `apsubmode`.
+#
+# Filed as ha_blueair#348 by @Pazuzu6666 (sanitized SP4i debug log) and
+# ha_blueair#261 by @madkatz01 / @disruptivepatternmaterial / @Pazuzu5688
+# (multiple Signature owners; same observed mapping).
+#
+# Phase 3 of dahlb/ha_blueair#334 (tracked as ha_blueair#353) will
+# consume this dict as the `value_labels` of a future
+# FieldProfile("apsubmode") and add `apsubmode` to the FieldProfile
+# deny-list so the schema-driven `select` does not duplicate the
+# fan-platform preset list.
+#
+# IMPORTANT: `apsubmode` is a POLYVALENT shadow slug — the same wire
+# field carries different value namespaces on different device
+# families. This dict is INTENTIONALLY Signature-only.
+#
+#   * Signature (blue40, hw='l_blue40'): values 0/2/3/4 mean
+#     manual_fan/auto/night/eco. The device has no other preset
+#     mechanism — `apsubmode` is the sole control.
+#
+#   * T10i (cmb3in1): values 1/2 only, and only meaningful while
+#     `mainmode==0` (HVAC FAN_ONLY). In HEAT mode `heatsubmode`
+#     supersedes; in COOL mode `coolsubmode` supersedes. T10i is
+#     surfaced via the HA climate platform, not the fan platform.
+#
+#   * pet_air_pro / 2-in-1 / older AWS purifiers: declare `apsubmode`
+#     in their schema but `ha_blueair` does not consume it — preset
+#     modes come from `automode` / `nightmode`. Value semantics TBD.
+#
+# The three families are kept disjoint by a capability gate in
+# ha_blueair's BlueairAwsFan:
+#   `ap_sub_mode != NotImplemented
+#    AND fan_auto_mode == NotImplemented
+#    AND night_mode == NotImplemented`
+# Only Signature devices pass that gate, so only Signature devices
+# consume AP_SUB_MODE_LABELS. T10i / pet_air_pro / 2-in-1 declare
+# `automode` and so are excluded.
+#
+# Consumers MUST NOT treat AP_SUB_MODE_LABELS as a global decoder
+# for `apsubmode` — that would mislabel T10i value 1 as missing
+# from the namespace when it is in fact a valid T10i value.
+#
+# NOTE on the manual_fan wire value: investigation of the Blueair
+# cloud API responses and AWS IoT protocol behavior suggests that
+# the canonical wire value for the manual / fan-speed-only mode is
+# **1**. The 0 mapping below is the value that was empirically
+# confirmed by the user who supplied the SP4i debug log (writing
+# apsubmode=0 successfully transitioned the SP4i into manual fan
+# mode and accepted subsequent fanspeed writes). Firmware appears
+# to accept either 0 or 1 as "exit current preset; resume manual
+# control" — keep 0 unless and until a tester confirms that
+# writing 1 has the same effect on real hardware. If 1 turns out
+# to be exclusively accepted by some firmware revision, switch
+# this mapping accordingly.
+AP_SUB_MODE_LABELS: dict[int, str] = {
+    0: "manual_fan",
+    2: "auto",
+    3: "night",
+    4: "eco",
+}
+
 @dataclass(slots=True)
 class DeviceAws(CallbacksMixin):
     @classmethod

--- a/tests/device_info/SP4i.json
+++ b/tests/device_info/SP4i.json
@@ -1,0 +1,994 @@
+{
+  "id": "00000000-0000-0000-0000-00000000sp4i",
+  "configuration": {
+    "df": {
+      "a": 877,
+      "ot": "Blue40_Filter",
+      "fsfc": 12600000,
+      "alg": "FilterAlg1"
+    },
+    "di": {
+      "cfv": "1.1.0",
+      "cma": "aa:bb:cc:dd:ee:ff",
+      "mt": "1",
+      "name": "Blueair SP4i",
+      "aqiranges": "{\"pm1\":[5,10,15,20,999],\"pm25\":[5,10,15,25,999],\"pm10\":[10,20,30,40,999]}",
+      "sku": "112936",
+      "region": "jp",
+      "mfv": "1.1.0",
+      "ofv": "1.1.0",
+      "hw": "l_blue40",
+      "ds": "112936000000000000000000"
+    },
+    "_ot": "CmConfig",
+    "_f": false,
+    "_it": "urn:blueair:openapi:version:blue40:0.0.5",
+    "_eid": "9e88402a-a10a-4c67-bd53-f2a041247296",
+    "_sc": "Instance",
+    "ds": {
+      "fu0": {
+        "tf": "senml+json",
+        "ot": "FU",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/fu0",
+        "ttl": -1,
+        "n": "fu0",
+        "fe": true
+      },
+      "timts": {
+        "tf": "senml+json",
+        "ot": "TimerTS",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/timts",
+        "ttl": 0,
+        "n": "timts",
+        "fe": true
+      },
+      "timdur": {
+        "tf": "senml+json",
+        "ot": "TimerDuration",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/timdur",
+        "ttl": 0,
+        "n": "timdur",
+        "fe": true
+      },
+      "ledb": {
+        "tf": "senml+json",
+        "ot": "Led",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/ledb",
+        "ttl": 0,
+        "n": "ledb",
+        "fe": true
+      },
+      "apsubmode": {
+        "tf": "senml+json",
+        "ot": "ApSubMode",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/apsubmode",
+        "ttl": 0,
+        "n": "apsubmode",
+        "fe": true
+      },
+      "startts": {
+        "tf": "senml+json",
+        "ot": "StartTs",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/startts",
+        "ttl": 0,
+        "n": "startts",
+        "fe": true
+      },
+      "aireta": {
+        "tf": "senml+json",
+        "ot": "AirETA",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/aireta",
+        "ttl": -1,
+        "n": "aireta",
+        "fe": true
+      },
+      "pm2_5c": {
+        "tf": "senml+json",
+        "ot": "PMParticleCount",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/pm2_5c",
+        "ttl": 0,
+        "n": "pm2_5c",
+        "fe": true
+      },
+      "sb": {
+        "tf": "senml+json",
+        "ot": "Standby",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/sb",
+        "ttl": -1,
+        "n": "sb",
+        "fe": true
+      },
+      "arstate": {
+        "tf": "senml+json",
+        "ot": "AirrefreshState",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/arstate",
+        "ttl": 0,
+        "n": "arstate",
+        "fe": true
+      },
+      "rt1s": {
+        "tf": "senml+json",
+        "ot": "RT1s",
+        "e": false,
+        "i": 1000,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/1s",
+        "sn": [
+          "pm1",
+          "pm2_5",
+          "pm10",
+          "rssi"
+        ],
+        "ttl": 0,
+        "n": "rt1s",
+        "fe": true
+      },
+      "nmledb": {
+        "tf": "senml+json",
+        "ot": "nmLed",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/nmledb",
+        "ttl": 0,
+        "n": "nmledb",
+        "fe": true
+      },
+      "hover": {
+        "tf": "senml+json",
+        "ot": "HOver",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/hover",
+        "ttl": -1,
+        "n": "hover",
+        "fe": true
+      },
+      "rt5s": {
+        "tf": "senml+json",
+        "ot": "RT5s",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/5s",
+        "sn": [
+          "pm1",
+          "pm2_5",
+          "pm10",
+          "rssi"
+        ],
+        "ttl": -1,
+        "n": "rt5s",
+        "fe": true
+      },
+      "pm1": {
+        "tf": "senml+json",
+        "ot": "PM1",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/pm1",
+        "ttl": 0,
+        "n": "pm1",
+        "fe": true
+      },
+      "mainmode": {
+        "tf": "senml+json",
+        "ot": "MainMode",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/mainmode",
+        "ttl": 0,
+        "n": "mainmode",
+        "fe": true
+      },
+      "pm2_5": {
+        "tf": "senml+json",
+        "ot": "PM2_5",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/pm2_5",
+        "ttl": 0,
+        "n": "pm2_5",
+        "fe": true
+      },
+      "uim": {
+        "tf": "senml+json",
+        "ot": "UnitIconMode",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/uim",
+        "ttl": -1,
+        "n": "uim",
+        "fe": true
+      },
+      "endts": {
+        "tf": "senml+json",
+        "ot": "EndTs",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/endts",
+        "ttl": 0,
+        "n": "endts",
+        "fe": true
+      },
+      "sp": {
+        "tf": "senml+json",
+        "ot": "SensorBoxPresense",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/sp",
+        "ttl": -1,
+        "n": "sp",
+        "fe": true
+      },
+      "arts": {
+        "tf": "senml+json",
+        "ot": "AirrefreshTs",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/arts",
+        "ttl": 0,
+        "n": "arts",
+        "fe": true
+      },
+      "timl": {
+        "tf": "senml+json",
+        "ot": "TimerLeft",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/timl",
+        "ttl": 0,
+        "n": "timl",
+        "fe": true
+      },
+      "rssi": {
+        "tf": "senml+json",
+        "ot": "RSSI",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/rssi",
+        "ttl": 0,
+        "n": "rssi",
+        "fe": true
+      },
+      "chl": {
+        "tf": "senml+json",
+        "ot": "ChildLock",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/chl",
+        "ttl": -1,
+        "n": "chl",
+        "fe": true
+      },
+      "fp0": {
+        "tf": "senml+json",
+        "ot": "FilterPresence",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/fp0",
+        "ttl": -1,
+        "n": "fp0",
+        "fe": true
+      },
+      "pm10": {
+        "tf": "senml+json",
+        "ot": "PM10",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/pm10",
+        "ttl": 0,
+        "n": "pm10",
+        "fe": true
+      },
+      "is": {
+        "tf": "senml+json",
+        "ot": "IonizerState",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/is",
+        "ttl": -1,
+        "n": "is",
+        "fe": true
+      },
+      "rt5m": {
+        "tf": "senml+json",
+        "ot": "RT5m",
+        "e": false,
+        "i": 300000,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/5m",
+        "sn": [
+          "pm1",
+          "pm2_5",
+          "pm10"
+        ],
+        "ttl": 0,
+        "n": "rt5m",
+        "fe": true
+      },
+      "roomtype": {
+        "tf": "senml+json",
+        "ot": "RoomType",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/roomtype",
+        "ttl": 0,
+        "n": "roomtype",
+        "fe": true
+      },
+      "ar": {
+        "tf": "senml+json",
+        "ot": "AirRefresh",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/ar",
+        "ttl": -1,
+        "n": "ar",
+        "fe": true
+      },
+      "timstate": {
+        "tf": "senml+json",
+        "ot": "TimerState",
+        "e": false,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/timstate",
+        "ttl": 0,
+        "n": "timstate",
+        "fe": true
+      },
+      "b5m": {
+        "tf": "senml+json",
+        "th": [
+          "5kb",
+          "300s"
+        ],
+        "ot": "Batch5m",
+        "e": true,
+        "i": 300000,
+        "tn": "$aws/rules/telemetry_ingest_rule/d/00000000-0000-0000-0000-00000000sp4i/s/batch/b5m",
+        "sn": [
+          "pm1",
+          "pm2_5",
+          "pm10",
+          "fsp0"
+        ],
+        "ttl": -1,
+        "n": "b5m",
+        "fe": true
+      },
+      "ardur": {
+        "tf": "senml+json",
+        "ot": "AirrefreshDur",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/ardur",
+        "ttl": 0,
+        "n": "ardur",
+        "fe": true
+      },
+      "fsp0": {
+        "st": "fsp0",
+        "tf": "senml+json",
+        "t": 10,
+        "ot": "Fanspeed",
+        "e": true,
+        "i": 0,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/s/fsp0",
+        "sn": [
+          "fsp0"
+        ],
+        "ttl": -1,
+        "n": "fsp0",
+        "fe": true
+      }
+    },
+    "_r": "eu-west-1",
+    "_s": {
+      "sig": "",
+      "salg": "SHA256withECDSA"
+    },
+    "_t": "Partial",
+    "_v": 1765598258,
+    "_cas": 1755908178,
+    "_id": "00000000-0000-0000-0000-00000000sp4i",
+    "fc": {
+      "bssid": "",
+      "pwd": "",
+      "ssid": "",
+      "url": ""
+    },
+    "da": {
+      "fu0": {
+        "p": true,
+        "st": "fu0",
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "FilterUsage",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/fu0",
+        "n": "fu0",
+        "fe": true
+      },
+      "localts": {
+        "p": true,
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "LocalTs",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/localts",
+        "n": "localts",
+        "fe": true
+      },
+      "timts": {
+        "p": true,
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "TimerStamp",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/timts",
+        "n": "timts",
+        "fe": true
+      },
+      "timdur": {
+        "p": true,
+        "a": 7200,
+        "tf": "senml+json",
+        "ot": "TimerDuration",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/timdur",
+        "n": "timdur",
+        "fe": true
+      },
+      "ledb": {
+        "p": true,
+        "a": 100,
+        "tf": "senml+json",
+        "ot": "LedBrightness",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/ledb",
+        "n": "ledb",
+        "fe": true
+      },
+      "apsubmode": {
+        "p": true,
+        "st": "apsubmode",
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "ApSubMode",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/apsubmode",
+        "n": "apsubmode",
+        "fe": true
+      },
+      "startts": {
+        "p": true,
+        "a": 36000,
+        "tf": "senml+json",
+        "ot": "StartTs",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/startts",
+        "n": "startts",
+        "fe": true
+      },
+      "sb": {
+        "p": true,
+        "a": false,
+        "tf": "senml+json",
+        "sbt": "sensor_on",
+        "ot": "Standby",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/sb",
+        "n": "sb",
+        "fe": true
+      },
+      "arstate": {
+        "p": true,
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "AirrefreshState",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/arstate",
+        "n": "arstate",
+        "fe": true
+      },
+      "nmledb": {
+        "p": true,
+        "a": 100,
+        "tf": "senml+json",
+        "ot": "NMLedBrightness",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/nmledb",
+        "n": "nmledb",
+        "fe": true
+      },
+      "hover": {
+        "p": true,
+        "a": false,
+        "tf": "senml+json",
+        "ot": "HOver",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/hover",
+        "n": "hover",
+        "fe": true
+      },
+      "mainmode": {
+        "p": true,
+        "st": "mainmode",
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "MainMode",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/mainmode",
+        "n": "mainmode",
+        "fe": true
+      },
+      "uim": {
+        "p": true,
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "UnitIconMode",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/uim",
+        "n": "uim",
+        "fe": true
+      },
+      "endts": {
+        "p": true,
+        "a": 64800,
+        "tf": "senml+json",
+        "ot": "EndTs",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/endts",
+        "n": "endts",
+        "fe": true
+      },
+      "arts": {
+        "p": true,
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "AirrefreshTs",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/arts",
+        "n": "arts",
+        "fe": true
+      },
+      "reboot": {
+        "p": false,
+        "a": false,
+        "ot": "Reboot",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/reboot",
+        "n": "reboot",
+        "fe": true
+      },
+      "timl": {
+        "p": true,
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "TimeLeft",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/timl",
+        "n": "timl",
+        "fe": true
+      },
+      "chl": {
+        "p": true,
+        "a": false,
+        "tf": "senml+json",
+        "ot": "ChildLock",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/chl",
+        "n": "chl",
+        "fe": true
+      },
+      "sflu": {
+        "p": false,
+        "a": false,
+        "ot": "SensorFlush",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/sflu",
+        "n": "sflu",
+        "fe": true
+      },
+      "is": {
+        "p": true,
+        "a": false,
+        "tf": "senml+json",
+        "ot": "IonizerState",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/is",
+        "n": "is",
+        "fe": true
+      },
+      "roomtype": {
+        "p": true,
+        "a": 2,
+        "tf": "senml+json",
+        "ot": "RoomType",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/roomtype",
+        "n": "roomtype",
+        "fe": true
+      },
+      "ar": {
+        "p": true,
+        "a": true,
+        "tf": "senml+json",
+        "sbt": "sensor_on",
+        "ot": "AirRefresh",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/ar",
+        "n": "ar",
+        "fe": true
+      },
+      "timstate": {
+        "p": true,
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "TimerState",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/timstate",
+        "n": "timstate",
+        "fe": true
+      },
+      "ardur": {
+        "p": true,
+        "a": 0,
+        "tf": "senml+json",
+        "ot": "AirrefreshDur",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/ardur",
+        "n": "ardur",
+        "fe": true
+      },
+      "fsp0": {
+        "p": true,
+        "st": "fsp0",
+        "a": 20,
+        "tf": "senml+json",
+        "ot": "Fanspeed",
+        "e": true,
+        "tn": "d/00000000-0000-0000-0000-00000000sp4i/a/fsp0",
+        "n": "fsp0",
+        "fe": true
+      }
+    },
+    "dc": {
+      "timts": {
+        "a": "timts",
+        "s": "timts",
+        "t": "integer",
+        "v": 0,
+        "n": "timts"
+      },
+      "filterusage": {
+        "a": "fu0",
+        "s": "fu0",
+        "t": "integer",
+        "v": 0,
+        "n": "filterusage"
+      },
+      "standby": {
+        "a": "sb",
+        "s": "sb",
+        "t": "boolean",
+        "v": false,
+        "n": "standby"
+      },
+      "timdur": {
+        "a": "timdur",
+        "s": "timdur",
+        "t": "integer",
+        "v": 7200,
+        "n": "timdur"
+      },
+      "nmbrightness": {
+        "a": "nmledb",
+        "s": "nmledb",
+        "t": "integer",
+        "v": 100,
+        "n": "nmbrightness"
+      },
+      "apsubmode": {
+        "a": "apsubmode",
+        "s": "apsubmode",
+        "t": "integer",
+        "v": 0,
+        "n": "apsubmode"
+      },
+      "startts": {
+        "a": "startts",
+        "s": "startts",
+        "t": "integer",
+        "v": 36000,
+        "n": "startts"
+      },
+      "aireta": {
+        "a": "aireta",
+        "s": "aireta",
+        "t": "integer",
+        "v": 0,
+        "n": "aireta"
+      },
+      "airrefresh": {
+        "a": "ar",
+        "s": "ar",
+        "t": "boolean",
+        "v": true,
+        "n": "airrefresh"
+      },
+      "arstate": {
+        "a": "arstate",
+        "s": "arstate",
+        "t": "integer",
+        "v": 0,
+        "n": "arstate"
+      },
+      "hover": {
+        "a": "hover",
+        "s": "hover",
+        "t": "boolean",
+        "v": false,
+        "n": "hover"
+      },
+      "mainmode": {
+        "a": "mainmode",
+        "s": "mainmode",
+        "t": "integer",
+        "v": 0,
+        "n": "mainmode"
+      },
+      "endts": {
+        "a": "endts",
+        "s": "endts",
+        "t": "integer",
+        "v": 64800,
+        "n": "endts"
+      },
+      "childlock": {
+        "a": "chl",
+        "s": "chl",
+        "t": "boolean",
+        "v": false,
+        "n": "childlock"
+      },
+      "arts": {
+        "a": "arts",
+        "s": "arts",
+        "t": "integer",
+        "v": 0,
+        "n": "arts"
+      },
+      "displaymode": {
+        "a": "uim",
+        "s": "uim",
+        "t": "integer",
+        "v": 0,
+        "n": "displaymode"
+      },
+      "timl": {
+        "a": "timl",
+        "s": "timl",
+        "t": "integer",
+        "v": 0,
+        "n": "timl"
+      },
+      "fanspeed": {
+        "a": "fsp0",
+        "s": "fsp0",
+        "t": "integer",
+        "v": 11,
+        "n": "fanspeed"
+      },
+      "roomtype": {
+        "a": "roomtype",
+        "s": "roomtype",
+        "t": "integer",
+        "v": 2,
+        "n": "roomtype"
+      },
+      "cfv": {
+        "d": "di.cfv",
+        "t": "integer",
+        "v": 0,
+        "n": "cfv"
+      },
+      "brightness": {
+        "a": "ledb",
+        "s": "ledb",
+        "t": "integer",
+        "v": 100,
+        "n": "brightness"
+      },
+      "timstate": {
+        "a": "timstate",
+        "s": "timstate",
+        "t": "integer",
+        "v": 0,
+        "n": "timstate"
+      },
+      "mfv": {
+        "d": "di.mfv",
+        "t": "integer",
+        "v": 0,
+        "n": "mfv"
+      },
+      "ardur": {
+        "a": "ardur",
+        "s": "ardur",
+        "t": "integer",
+        "v": 0,
+        "n": "ardur"
+      },
+      "ofv": {
+        "d": "di.ofv",
+        "t": "integer",
+        "v": 0,
+        "n": "ofv"
+      }
+    }
+  },
+  "alarms": [],
+  "events": [],
+  "sensordata": [],
+  "states": [
+    {
+      "n": "timts",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "filterusage",
+      "v": 44,
+      "t": 1778270607
+    },
+    {
+      "n": "standby",
+      "vb": false,
+      "t": 1778270607
+    },
+    {
+      "n": "timdur",
+      "v": 7200,
+      "t": 1778270607
+    },
+    {
+      "n": "nmbrightness",
+      "v": 7,
+      "t": 1778270607
+    },
+    {
+      "n": "apsubmode",
+      "v": 2,
+      "t": 1778292002
+    },
+    {
+      "n": "startts",
+      "v": 36000,
+      "t": 1778270607
+    },
+    {
+      "n": "aireta",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "airrefresh",
+      "vb": false,
+      "t": 1778270607
+    },
+    {
+      "n": "arstate",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "hover",
+      "vb": true,
+      "t": 1778270607
+    },
+    {
+      "n": "mainmode",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "endts",
+      "v": 64800,
+      "t": 1778270607
+    },
+    {
+      "n": "childlock",
+      "vb": false,
+      "t": 1778270607
+    },
+    {
+      "n": "arts",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "displaymode",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "timl",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "fanspeed",
+      "v": 11,
+      "t": 1778292003
+    },
+    {
+      "n": "roomtype",
+      "v": 2,
+      "t": 1778270607
+    },
+    {
+      "n": "cfv",
+      "v": 16777472,
+      "t": 1778270607
+    },
+    {
+      "n": "brightness",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "timstate",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "mfv",
+      "v": 16777472,
+      "t": 1778270607
+    },
+    {
+      "n": "ardur",
+      "v": 0,
+      "t": 1778270607
+    },
+    {
+      "n": "ofv",
+      "v": 16777472,
+      "t": 1778270607
+    },
+    {
+      "t": 1778270607,
+      "vb": true,
+      "n": "online"
+    }
+  ],
+  "welcomehome": {
+    "setting": {
+      "textValue": "\u6c11\u6b0a\u8def75\u865f",
+      "lng": 0,
+      "radius": 3000,
+      "lat": 0
+    }
+  },
+  "fleet_info": [],
+  "location_id": "",
+  "timezone": "Asia/Taipei"
+}

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -18,7 +18,7 @@ import dataclasses
 from importlib import resources
 import json
 from unittest import mock
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 
 import pytest
 
@@ -736,6 +736,100 @@ class T10iTest(DeviceAwsTestBase):
             assert device.hour_format is NotImplemented
 
 
+class SP4iTest(DeviceAwsTestBase):
+    """Tests for the Blueair Blue Signature SP4i (blue40 / l_blue40).
+
+    Fixture captured from a sanitized debug log shared by @Pazuzu6666
+    on dahlb/ha_blueair#348. The device declares `apsubmode` but NOT
+    `automode` or `nightmode`, which is the capability signature
+    `ha_blueair` uses to enable Signature preset modes
+    (manual_fan / auto / night / eco) via AP_SUB_MODE_LABELS.
+    """
+
+    def setUp(self):
+        super().setUp()
+        with open(resources.files().joinpath('device_info/SP4i.json')) as sample_file:
+            info = json.load(sample_file)
+        self.device_info_helper.info.update(info)
+
+    async def test_attributes(self):
+
+        await self.device.refresh()
+        self.api.device_info.assert_awaited_with("fake-name-api", "fake-uuid")
+
+        with assert_fully_checked(self.device) as device:
+
+            assert device.model_name == "Blueair Blue Signature SP4i"
+
+            assert device.pm1 is None
+            assert device.pm2_5 is None
+            assert device.pm10 is None
+            assert device.total_voc is NotImplemented
+            assert device.voc is NotImplemented
+            assert device.temperature is NotImplemented
+            assert device.humidity is NotImplemented
+            assert device.name == "Blueair SP4i"
+            assert device.firmware == "1.1.0"
+            assert device.mcu_firmware == "1.1.0"
+            assert device.serial_number == "112936000000000000000000"
+            assert device.sku == "112936"
+            assert device.hw == "l_blue40"
+
+            assert device.standby is False
+            # Signature devices do NOT declare automode/nightmode in dc:
+            # this is the capability signature ha_blueair gates the
+            # Signature preset modes on.
+            assert device.fan_auto_mode is NotImplemented
+            assert device.night_mode is NotImplemented
+            assert device.germ_shield is NotImplemented
+            assert device.brightness == 0
+            assert device.child_lock is False
+            assert device.fan_speed == 11
+            assert device.filter_usage_percentage == 44
+            assert device.wifi_working is True
+            assert device.wick_usage_percentage is NotImplemented
+            assert device.auto_regulated_humidity is NotImplemented
+            assert device.water_shortage is NotImplemented
+            assert device.wick_dry_mode is NotImplemented
+            assert device.main_mode == 0
+            assert device.heat_temp is NotImplemented
+            assert device.heat_sub_mode is NotImplemented
+            assert device.heat_fan_speed is NotImplemented
+            assert device.cool_sub_mode is NotImplemented
+            assert device.cool_fan_speed is NotImplemented
+            # apsubmode=2 (auto) in the captured shadow.
+            assert device.ap_sub_mode == 2
+            # fsp0 is declared in `ds` (sensor schema) but NOT in `dc`
+            # (control schema) on SP4i, so refresh() falls back to the
+            # sensor history. The fixture's `sensordata` is empty, so
+            # the latest value is None. On a live device the MQTT 5s
+            # feed populates this between refreshes.
+            assert device.fan_speed_0 is None
+            assert device.temperature_unit is NotImplemented
+            assert device.mood_brightness is NotImplemented
+            assert device.water_refresher_usage_percentage is NotImplemented
+            assert device.water_level is NotImplemented
+            assert device.rssi is None
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 7200
+            assert device.hour_format is NotImplemented
+
+    async def test_mqtt_sensor_slugs(self):
+        """SP4i rt5s declares the four MQTT slugs we expect.
+
+        Note: `fsp0` is published on its OWN MQTT topic
+        (`d/<id>/s/fsp0`) and is not part of the 5-second batch.
+        `mqtt_sensor_slugs` only reflects `rt5s.sn`.
+        """
+        await self.device.refresh()
+        assert self.device.mqtt_sensor_slugs == [
+            "pm1", "pm2_5", "pm10", "rssi"
+        ]
+
+
 class Protect7470iTest(DeviceAwsTestBase):
     """Tests for protect7470i."""
 
@@ -1213,6 +1307,66 @@ class ModelNameTest(DeviceAwsTestBase):
         """Missing SKU (NotImplemented) falls back gracefully."""
         await self.device.refresh()
         assert UNKNOWN_MODEL in self.device.model_name
+
+    async def test_sp4i_sku_known(self):
+        """SP4i SKU 112936 resolves to Blueair Blue Signature SP4i.
+
+        Regression for ha_blueair#348 / #261 — the Signature/SP4i fan
+        preset support depends on correct SKU resolution so the device
+        appears as a Signature device in HA's device registry.
+        """
+        ir.query_json(self.device_info_helper.info, "configuration.di")["sku"] = "112936"
+        await self.device.refresh()
+        assert self.device.model_name == "Blueair Blue Signature SP4i"
+
+
+class ApSubModeLabelsTest(TestCase):
+    """Regression tests for the AP_SUB_MODE_LABELS public constant.
+
+    Consumed by ha_blueair's fan platform to expose Signature/SP4i fan
+    preset modes (ha_blueair#348, #261). Changing these labels is a
+    breaking API change for downstream integrations — keep this test
+    in sync with const expectations on the consumer side.
+
+    AP_SUB_MODE_LABELS is intentionally Signature-only. It is NOT a
+    global decoder for the `apsubmode` shadow slug: T10i (cmb3in1)
+    uses values 1/2 in a different namespace and pet_air_pro / 2-in-1
+    declare the field without consuming it. See the constant's
+    docstring in src/blueair_api/device_aws.py.
+    """
+
+    def test_labels_match_known_signature_mapping(self):
+        from blueair_api.device_aws import AP_SUB_MODE_LABELS
+        assert AP_SUB_MODE_LABELS == {
+            0: "manual_fan",
+            2: "auto",
+            3: "night",
+            4: "eco",
+        }
+
+    def test_labels_are_unique(self):
+        """Two values mapping to the same preset would silently break
+        the consumer's reverse lookup (label -> apsubmode value)."""
+        from blueair_api.device_aws import AP_SUB_MODE_LABELS
+        assert len(set(AP_SUB_MODE_LABELS.values())) == len(AP_SUB_MODE_LABELS)
+
+    def test_labels_are_well_formed(self):
+        """Keys must be ints (the apsubmode wire type) and values must
+        be non-empty strings (HA preset_modes are str-typed)."""
+        from blueair_api.device_aws import AP_SUB_MODE_LABELS
+        assert all(isinstance(k, int) for k in AP_SUB_MODE_LABELS)
+        assert all(
+            isinstance(v, str) and v
+            for v in AP_SUB_MODE_LABELS.values()
+        )
+
+    def test_publicly_importable_from_package_root(self):
+        """Phase 3 (ha_blueair#353) and current ha_blueair#348 consumers
+        should be able to import the constant from the package root,
+        not reach into device_aws."""
+        import blueair_api
+        from blueair_api.device_aws import AP_SUB_MODE_LABELS
+        assert blueair_api.AP_SUB_MODE_LABELS is AP_SUB_MODE_LABELS
 
 
 class MqttSensorSlugsTest(DeviceAwsTestBase):


### PR DESCRIPTION
# feat: expose `AP_SUB_MODE_LABELS` for Signature/SP4i fan presets

## Summary

Adds a public `AP_SUB_MODE_LABELS: dict[int, str]` constant to
`blueair_api` mapping the four `apsubmode` integer values observed on
Signature-series air purifiers to their consumer-facing preset labels:

| Wire value | Label |
|---|---|
| `0` | `manual_fan` |
| `2` | `auto` |
| `3` | `night` |
| `4` | `eco` |

The constant is consumed by [`dahlb/ha_blueair#348`][1] / [`#261`][2]
to expose Signature fan preset modes in Home Assistant. This PR ships
**only the library piece** (constant + fixture + tests); the
integration change is a separate PR that will pin to the release that
ships from this PR.

No behavior change to any existing device — `apsubmode` was already
plumbed end-to-end through `SHADOW_FIELD_MAP`, `refresh()`, and
`set_ap_sub_mode` in v1.51.0. This PR adds **only** the public label
map and regression coverage.

[1]: https://github.com/dahlb/ha_blueair/issues/348
[2]: https://github.com/dahlb/ha_blueair/issues/261

## Why a library constant (vs. in `ha_blueair`)?

Three reasons:

1. **Forward compatibility with Phase 3 (`ha_blueair#353`)** — the
   schema-driven entity discovery work explicitly designs a per-slug
   `FieldProfile` registry whose `value_labels` field is exactly this
   dict's shape. Keeping the mapping in `blueair_api` lets the future
   registry import it directly instead of re-discovering the SP4i
   values.
2. **Single source of truth across consumers.** If a future client
   (Home Assistant integration, CLI, dashboard) wants the same
   preset list, they should not each maintain their own copy.
3. **Pattern consistency.** `MQTT_SENSOR_FIELD_MAP` and
   `SHADOW_FIELD_MAP` already live in `device_aws.py`; this is the
   same idiom.

## Why a constant and not an Enum or Literal type?

The `apsubmode` shadow slug is **polyvalent** across device families
(see the constant's docstring). An `Enum` declaring "the legal values
of `apsubmode`" would either:
- be wrong (Signature has 0/2/3/4; T10i uses 1/2; pet_air_pro
  declares the slug but ignores it), or
- need per-family enum classes, which is more abstraction than the
  current state of the codebase asks for.

A plain dict keyed by int with a long disambiguating docstring keeps
the contract honest: this map is **Signature-family only**, NOT a
global `apsubmode` decoder. The docstring spells out the three known
namespaces and how `ha_blueair`'s fan platform keeps them disjoint
via a capability gate (`ap_sub_mode != NotImplemented AND
fan_auto_mode == NotImplemented AND night_mode == NotImplemented`).

## What's in this PR

### `src/blueair_api/device_aws.py`
- New top-level constant `AP_SUB_MODE_LABELS` with a docstring that
  explains polyvalent-slug pitfalls and Phase 3 forward compatibility.

### `src/blueair_api/__init__.py`
- Re-exports `AP_SUB_MODE_LABELS` from the package root so
  downstream consumers can `from blueair_api import
  AP_SUB_MODE_LABELS` (stable import contract).

### `tests/device_info/SP4i.json`
- New fixture derived from a sanitized SP4i `device_info` response
  shared by @Pazuzu6666 in
  [`ha_blueair#348`](https://github.com/dahlb/ha_blueair/issues/348#issuecomment-…).
  All user-identifying tokens (UUIDs, MAC, serial, account ID,
  Wi-Fi credentials, home address, lat/lon, auth tokens) are
  replaced with synthetic placeholders following the same
  convention as the existing `T10i.json` and `pet_air_pro.json`
  fixtures.

### `tests/test_device_aws.py`
- New `SP4iTest` mirrors `T10iTest` / `Max211iTest`. Loads the
  fixture, runs `refresh()`, and asserts the full attribute set
  via `assert_fully_checked`. Pinpoints the capability signature:
  - `ap_sub_mode == 2`
  - `fan_auto_mode is NotImplemented`
  - `night_mode is NotImplemented`
  - `model_name == "Blueair Blue Signature SP4i"` (SKU `112936`)
  - `mqtt_sensor_slugs == ["pm1", "pm2_5", "pm10", "rssi"]`
- New `ModelNameTest.test_sp4i_sku_known` covers the SKU table
  entry directly.
- New `ApSubModeLabelsTest` (4 tests):
  - `test_labels_match_known_signature_mapping` — locks the
    canonical 0/2/3/4 → manual_fan/auto/night/eco mapping.
  - `test_labels_are_unique` — guards against silent reverse-lookup
    breakage.
  - `test_labels_are_well_formed` — int keys, non-empty string
    values.
  - `test_publicly_importable_from_package_root` — protects the
    `__init__.py` re-export against future refactors.

## Validation

```
pytest tests -q
............................................................[ 53%]
............................................................[100%]
135 passed in 3.32s

ruff check src/ tests/
All checks passed!

mypy src/blueair_api/device_aws.py
Success: no issues found in 1 source file
```

## Versioning

Suggest **v1.51.1** patch release after merge — additive public API,
no behavior change, no migration concerns.

## Related

- Closes part of (but not all of) `dahlb/ha_blueair#348` —
  integration-side fan-platform change ships in a separate PR
  against `dahlb/ha_blueair:main` after this lands.
- Closes part of `dahlb/ha_blueair#261` (Signature Modes umbrella).
- Forward-compat hook for `dahlb/ha_blueair#353` (Phase 3
  schema-driven entity discovery) — the registry's
  `FieldProfile("apsubmode")` will consume this dict as
  `value_labels` once that work starts.
