### PR TITLE
feat: split Gigya/BlueCloud regions and add read-only region discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# blueair_api
+
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
 [![License][license-shield]](LICENSE)
@@ -5,21 +7,33 @@
 ![Project Maintenance][maintenance-shield]
 [![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
 
-Api Wrapper for BlueAir API using async in python, this was inspired by [this guide](https://developers.home-assistant.io/docs/api_lib_index) to be a lightweight wrapper, with simple error handling.
+Api Wrapper for BlueAir API using async in python. This was inspired by
+[this guide](https://developers.home-assistant.io/docs/api_lib_index) to be a
+lightweight wrapper with simple error handling.
 
 a lot of this is based on [hass-blueair](https://github.com/aijayadams/hass-blueair).
 
 ## Features
 
-- **REST API** — async device discovery, sensor polling, and control commands (fan speed, brightness, child lock, etc.) for both legacy and AWS-based Blueair devices
-- **MQTT real-time updates** — receive sensor data (PM2.5, temperature, humidity, etc.) and device state changes via AWS IoT WebSocket with sub-second latency instead of 5-minute polling
-- **Automatic reconnect with credential refresh** — MQTT tokens expire after 24 hours; the client refreshes credentials and reconnects with exponential backoff (5s → 300s max) on unexpected disconnects
-- **Data-driven SKU mapping** — resolves 418+ device SKUs to human-readable product names (e.g., `111582` → "Blueair Blue Pure 511i Max") via a built-in lookup table
-- **Per-device hardware detection** — `mood_brightness_max` and `fan_speed_count` adapt automatically based on the device's hardware identifier
+- **REST API** — async device discovery, sensor polling, and control commands
+  for both legacy and AWS-based Blueair devices.
+- **MQTT real-time updates** — receive sensor data and device state changes via
+  AWS IoT WebSocket with sub-second latency instead of 5-minute polling.
+- **Automatic reconnect with credential refresh** — MQTT tokens expire after 24
+  hours; the client refreshes credentials and reconnects with exponential
+  backoff on unexpected disconnects.
+- **Split AWS regions when needed** — keep the normal single `region` setting
+  for most accounts, or configure separate Gigya account and BlueCloud
+  device-control regions for accounts whose devices are hosted elsewhere. See
+  [AWS account and BlueCloud regions](docs/regions.md).
+- **Data-driven SKU mapping** — resolves device SKUs to human-readable product
+  names via a built-in lookup table.
+- **Per-device hardware detection** — `mood_brightness_max` and
+  `fan_speed_count` adapt automatically based on the device's hardware
+  identifier.
 
 ***
 
-[blueair_api]: https://github.com/dahlb/blueair_api
 [commits-shield]: https://img.shields.io/github/commit-activity/y/dahlb/blueair_api.svg?style=for-the-badge
 [commits]: https://github.com/dahlb/blueair_api/commits/main
 [license-shield]: https://img.shields.io/github/license/dahlb/blueair_api.svg?style=for-the-badge

--- a/docs/regions.md
+++ b/docs/regions.md
@@ -1,0 +1,151 @@
+# AWS Account and BlueCloud Regions
+
+Most AWS-backed Blueair accounts use the same region for account login and
+device control. For those accounts, keep using the existing `region` argument:
+
+```python
+from blueair_api import get_aws_devices
+
+api, devices = await get_aws_devices(
+    username="user@example.com",
+    password="password",
+    region="us",
+)
+```
+
+`region` remains a compatibility shortcut. It sets both the Gigya account
+region and the BlueCloud REST/MQTT region when no more specific value is
+provided.
+
+Some accounts are different: the user account logs in through one Gigya region,
+but the device's live BlueCloud control plane is hosted in another region. In
+that case, passing only `region="eu"` may fail account login, while passing only
+`region="us"` may authenticate successfully but read stale device state from the
+wrong BlueCloud backend.
+
+For those accounts, configure the two sides independently:
+
+```python
+from blueair_api import get_aws_devices
+
+api, devices = await get_aws_devices(
+    username="user@example.com",
+    password="password",
+    gigya_region="us",
+    cloud_region="eu",
+)
+```
+
+The same split is available when constructing the HTTP client directly:
+
+```python
+from blueair_api import HttpAwsBlueair
+
+api = HttpAwsBlueair(
+    username="user@example.com",
+    password="password",
+    gigya_region="us",
+    cloud_region="eu",
+)
+```
+
+`gigya_region` controls account login and JWT refresh. `cloud_region` controls
+BlueCloud REST calls and AWS IoT MQTT broker selection. The legacy `api.region`
+property returns `cloud_region` so older MQTT callers continue to select the
+device-control region.
+
+## Explicit Region Discovery
+
+`blueair_api` does not automatically scan regions during normal startup,
+refresh, polling, or control calls. Discovery is intended for explicit user
+flows, such as a config-flow "Detect cloud region" button, a reconfigure dialog,
+or a Home Assistant Repair fix flow.
+
+Use `discover_cloud_region()` when you already have a client with the user's
+known account-login region and you want a recommendation for the BlueCloud
+region. The probe logs in to each candidate BlueCloud region, reads its
+registered device list, and checks device status so stale mirrored regions do
+not win just because they still list the device:
+
+```python
+from blueair_api import HttpAwsBlueair
+
+api = HttpAwsBlueair(
+    username="user@example.com",
+    password="password",
+    gigya_region="us",
+    cloud_region="us",  # current or default selection
+)
+
+scan = await api.discover_cloud_region()
+
+if scan.winner and scan.changed:
+    print(
+        f"BlueCloud region {scan.winner!r} returned devices; "
+        f"current selection is {scan.selected_region!r}."
+    )
+```
+
+Discovery returns a `CloudRegionScan` object. Important fields:
+
+- `selected_region`: the `cloud_region` configured on the client when discovery
+  ran.
+- `candidates_tried`: region keys actually probed, after invalid candidates and
+  duplicate BlueCloud hosts are removed.
+- `per_region`: detailed `CandidateProbe` results for each attempted region.
+- `winner`: the recommended BlueCloud region, or `None` if no candidate returned
+  devices.
+- `changed`: `True` when `winner` differs from `selected_region`.
+- `multi_region_detected`: `True` when more than one BlueCloud region returned
+  devices.
+
+The probe is read-only with respect to the client. It may refresh the Gigya JWT
+if needed, but it does not change `api.cloud_region`, does not write a persistent
+access token, and does not switch regions for you. Applications should show the
+recommendation to the user and persist the confirmed `cloud_region` in their own
+configuration.
+
+Example integration flow:
+
+```python
+scan = await api.discover_cloud_region(candidates=["us", "eu", "cn", "au"])
+
+if scan.winner is None:
+    # Keep the user's current/default choice and allow manual override.
+    suggested_cloud_region = api.cloud_region
+elif scan.multi_region_detected:
+    # Show a stronger prompt; this account appears to own devices in more than
+    # one BlueCloud region, and one config entry can usually target only one.
+    suggested_cloud_region = scan.winner
+else:
+    suggested_cloud_region = scan.winner
+
+# Present suggested_cloud_region to the user. After confirmation, create a new
+# client or config entry with cloud_region=suggested_cloud_region.
+```
+
+## Detecting a Frozen Device Snapshot
+
+`device_state_looks_frozen()` helps integrations decide when to offer a repair
+or reconfigure flow. It inspects one `/r/initial` device payload and returns
+`True` only for the structural signature of a likely wrong-region snapshot:
+
+- missing or empty `states`, or
+- `online=False` and every state entry shares a single numeric timestamp.
+
+It does not use wall-clock age. A genuinely offline device with varied state
+timestamps is not flagged.
+
+```python
+from blueair_api import device_state_looks_frozen
+
+initial_payload = await api.device_info(device_name, device_uuid)
+
+if device_state_looks_frozen(initial_payload):
+    # Raise a repair issue or offer a reconfigure action that calls
+    # api.discover_cloud_region() and asks the user to confirm the result.
+    ...
+```
+
+This helper is diagnostic only. Avoid silently changing the user's configured
+region from this signal alone; use it to invite confirmation.

--- a/src/blueair_api/__init__.py
+++ b/src/blueair_api/__init__.py
@@ -2,6 +2,12 @@ from .errors import BaseError, RateError, AuthError, SessionError, LoginError
 from .http_blueair import HttpBlueair
 from .http_aws_blueair import HttpAwsBlueair
 from .mqtt_aws_blueair import MqttAwsBlueair
+from .region_discovery import (
+    CandidateProbe,
+    CloudRegionScan,
+    device_state_looks_frozen,
+    discover_cloud_region,
+)
 from .util_bootstrap import get_devices, get_aws_devices
 from .device import Device
 from .device_aws import DeviceAws, AP_SUB_MODE_LABELS

--- a/src/blueair_api/http_aws_blueair.py
+++ b/src/blueair_api/http_aws_blueair.py
@@ -363,3 +363,26 @@ class HttpAwsBlueair:
         )
         response_text = await response.text()
         return response_text == "Success"
+
+    async def discover_cloud_region(
+        self,
+        *,
+        candidates=None,
+        per_candidate_timeout: float = 5.0,
+    ):
+        """Probe candidate BlueCloud regions and return a recommendation.
+
+        Thin wrapper around :func:`blueair_api.region_discovery.discover_cloud_region`
+        so callers can do ``await api.discover_cloud_region()``.  Read-only
+        with respect to client state; see the free function's docstring
+        for the full contract.
+        """
+        # Local import to avoid a circular dependency at module load
+        # time (region_discovery imports HttpAwsBlueair for type hints).
+        from .region_discovery import discover_cloud_region
+
+        return await discover_cloud_region(
+            self,
+            candidates=candidates,
+            per_candidate_timeout=per_candidate_timeout,
+        )

--- a/src/blueair_api/http_aws_blueair.py
+++ b/src/blueair_api/http_aws_blueair.py
@@ -77,10 +77,52 @@ class HttpAwsBlueair:
         password: str,
         region: str = "us",
         client_session: ClientSession | None = None,
+        *,
+        gigya_region: str | None = None,
+        cloud_region: str | None = None,
     ):
+        """Construct the Blueair AWS HTTP client.
+
+        Parameters
+        ----------
+        username, password
+            Account credentials.
+        region
+            Convenience knob that drives both Gigya account region and
+            BlueCloud REST/MQTT region when neither ``gigya_region`` nor
+            ``cloud_region`` is supplied.  Defaults to ``"us"``.
+            Existing single-region callers should keep using this and
+            see no behavior change.
+        gigya_region
+            Optional override for the Gigya account-auth region
+            (controls ``accounts.login`` / ``accounts.getJWT`` host and
+            the Gigya partner API key).  Defaults to ``region``.
+        cloud_region
+            Optional override for the BlueCloud REST + MQTT region
+            (controls ``execute-api`` host and ``iot.amazonaws.com``
+            broker).  Defaults to ``region``.
+
+        Most accounts have ``gigya_region == cloud_region``.  Splitting
+        them is only needed when the device's live AWS IoT broker is
+        hosted in a different region than the account's Gigya tenant
+        (e.g. US Gigya account whose hardware is provisioned against
+        ``eu-west-1``).
+        """
         self.username = username
         self.password = password
-        self.region = region
+        self.gigya_region = gigya_region if gigya_region is not None else region
+        self.cloud_region = cloud_region if cloud_region is not None else region
+
+        if self.gigya_region not in AWS_APIKEYS:
+            raise ValueError(
+                f"Unknown gigya_region {self.gigya_region!r}; expected one of "
+                f"{sorted(AWS_APIKEYS)}"
+            )
+        if self.cloud_region not in AWS_APIKEYS:
+            raise ValueError(
+                f"Unknown cloud_region {self.cloud_region!r}; expected one of "
+                f"{sorted(AWS_APIKEYS)}"
+            )
 
         self.session_token = None
         self.session_secret = None
@@ -101,6 +143,32 @@ class HttpAwsBlueair:
 
     async def cleanup_client_session(self):
         await self.api_session.close()
+
+    @property
+    def region(self) -> str:
+        """Back-compat alias for ``cloud_region``.
+
+        Older callers (notably ``mqtt_aws_blueair.MqttAwsBlueair`` and
+        the Home Assistant integration's bootstrap path) read
+        ``http_client.region`` to look up the MQTT broker / AWS IoT
+        endpoint.  Those callers want the *cloud* region, so we expose
+        ``cloud_region`` under the legacy name to avoid breaking them.
+        """
+        return self.cloud_region
+
+    @region.setter
+    def region(self, value: str) -> None:
+        # Setting .region post-construction is undocumented but
+        # historically possible; keep both halves in lock-step so
+        # subclasses or test fixtures that reassign it don't end up
+        # with a Gigya/Cloud split they didn't ask for.
+        if value not in AWS_APIKEYS:
+            raise ValueError(
+                f"Unknown region {value!r}; expected one of "
+                f"{sorted(AWS_APIKEYS)}"
+            )
+        self.gigya_region = value
+        self.cloud_region = value
 
     @request_with_errors
     @request_with_logging
@@ -124,9 +192,9 @@ class HttpAwsBlueair:
 
     async def refresh_session(self) -> None:
         _LOGGER.debug("refresh_session")
-        url = f"https://{AWS_APIKEYS[self.region]['gigyaRegion']}/accounts.login"
+        url = f"https://{AWS_APIKEYS[self.gigya_region]['gigyaRegion']}/accounts.login"
         form_data = FormData()
-        form_data.add_field("apikey", AWS_APIKEYS[self.region]["apiKey"])
+        form_data.add_field("apikey", AWS_APIKEYS[self.gigya_region]["apiKey"])
         form_data.add_field("loginID", self.username)
         form_data.add_field("password", self.password)
         form_data.add_field("targetEnv", "mobile")
@@ -143,7 +211,7 @@ class HttpAwsBlueair:
         _LOGGER.debug("refresh_jwt")
         if self.session_token is None or self.session_secret is None:
             await self.refresh_session()
-        url = f"https://{AWS_APIKEYS[self.region]['gigyaRegion']}/accounts.getJWT"
+        url = f"https://{AWS_APIKEYS[self.gigya_region]['gigyaRegion']}/accounts.getJWT"
         form_data = FormData()
         form_data.add_field("oauth_token", self.session_token)
         form_data.add_field("secret", self.session_secret)
@@ -167,7 +235,7 @@ class HttpAwsBlueair:
         self.session_secret = None
         self.jwt = None
         await self.refresh_jwt()
-        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/login"
+        url = f"https://{AWS_APIKEYS[self.cloud_region]['restApiId']}.execute-api.{AWS_APIKEYS[self.cloud_region]['awsRegion']}/prod/c/login"
         headers = {"idtoken": self.jwt, "authorization": f"Bearer {self.jwt}"}
         response: ClientResponse = (
             await self._post_request_with_logging_and_errors_raised(
@@ -216,7 +284,7 @@ class HttpAwsBlueair:
     @request_with_active_session
     async def devices(self) -> dict[str, Any]:
         _LOGGER.debug("devices")
-        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/registered-devices"
+        url = f"https://{AWS_APIKEYS[self.cloud_region]['restApiId']}.execute-api.{AWS_APIKEYS[self.cloud_region]['awsRegion']}/prod/c/registered-devices"
         headers = {
             "Authorization": f"Bearer {await self.get_access_token()}",
         }
@@ -231,7 +299,7 @@ class HttpAwsBlueair:
     @request_with_active_session
     async def device_sensors(self, device_name, device_uuid, duration: timedelta = timedelta(hours=10)):
         user_id = await self.get_user_id()
-        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/{user_id}/r/telemetry/5m/historical"
+        url = f"https://{AWS_APIKEYS[self.cloud_region]['restApiId']}.execute-api.{AWS_APIKEYS[self.cloud_region]['awsRegion']}/prod/c/{user_id}/r/telemetry/5m/historical"
         headers = {
             "Authorization": f"Bearer {await self.get_access_token()}",
         }
@@ -253,7 +321,7 @@ class HttpAwsBlueair:
     async def device_info(self, device_name, device_uuid) -> dict[str, Any]:
         _LOGGER.debug("device_info")
         user_id = await self.get_user_id()
-        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/{user_id}/r/initial"
+        url = f"https://{AWS_APIKEYS[self.cloud_region]['restApiId']}.execute-api.{AWS_APIKEYS[self.cloud_region]['awsRegion']}/prod/c/{user_id}/r/initial"
         headers = {
             "Authorization": f"Bearer {await self.get_access_token()}",
         }
@@ -283,7 +351,7 @@ class HttpAwsBlueair:
         self, device_uuid, service_name, action_verb, action_value
     ) -> bool:
         _LOGGER.debug("set_device_info")
-        url = f"https://{AWS_APIKEYS[self.region]['restApiId']}.execute-api.{AWS_APIKEYS[self.region]['awsRegion']}/prod/c/{device_uuid}/a/{service_name}"
+        url = f"https://{AWS_APIKEYS[self.cloud_region]['restApiId']}.execute-api.{AWS_APIKEYS[self.cloud_region]['awsRegion']}/prod/c/{device_uuid}/a/{service_name}"
         headers = {
             "Authorization": f"Bearer {await self.get_access_token()}",
         }

--- a/src/blueair_api/region_discovery.py
+++ b/src/blueair_api/region_discovery.py
@@ -1,0 +1,479 @@
+"""BlueCloud region discovery — diagnostic primitives.
+
+This module provides two read-only helpers the integration layer can
+call explicitly when the user (or the integration's own diagnostic
+flow) needs to decide which BlueCloud region an account's hardware
+lives in.  See issue #312.
+
+* :func:`device_state_looks_frozen` — pure inspector that returns
+  ``True`` when an ``/r/initial`` payload has the structural signature
+  of a wrong-region snapshot: missing/empty ``states``, or
+  ``online=False`` combined with every state sharing a single
+  timestamp.
+
+* :meth:`HttpAwsBlueair.discover_cloud_region` — async probe that
+    reuses the client's existing Gigya JWT to call ``/c/login`` and
+    ``/c/registered-devices`` on each candidate BlueCloud region, then
+    checks ``/c/device-status`` for returned devices.  It reports
+    per-candidate device counts, online counts, and a recommended winner.  The
+  probe is **read-only and side-effect-free**: it does not mutate
+  ``cloud_region``, ``access_token``, or any other client attribute.
+
+Design intent
+-------------
+
+Neither primitive is invoked from the library's normal authentication
+or refresh paths.  The integration layer is expected to call them
+**only on explicit user action** — for example, from a config-flow
+"Detect cloud region" button or from a Repair-issue Fix dialog.  This
+keeps run-to-run behavior deterministic: once the user (or the user-
+confirmed discovery result) writes ``cloud_region`` into the config
+entry, the library reads that value every time and never silently
+re-chooses on its own.
+
+Implementation notes
+--------------------
+
+* The same Gigya JWT is accepted by every BlueCloud regional
+  ``/c/login`` endpoint, so we authenticate against Gigya once and
+  fan out cheaply.
+* Each candidate probe is bounded by a short per-region timeout so a
+    hanging region (e.g. ``cn`` from outside China) can't stall discovery
+    indefinitely.
+* All probes log at ``DEBUG``; only a *meaningful* multi-region
+  finding surfaces above debug.  Probes never log ``INFO`` for
+  "discovery confirmed the configured region" — the caller already
+  knows the outcome from the returned scan.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from aiohttp import ClientError
+
+from .const import AWS_APIKEYS
+
+if TYPE_CHECKING:
+    from .http_aws_blueair import HttpAwsBlueair
+
+_LOGGER = logging.getLogger(__name__)
+
+# Default per-candidate probe timeout in seconds.  Set short so a
+# region that simply can't be reached (firewalls, GFW, etc.) has a
+# bounded impact on explicit discovery.
+_DEFAULT_PER_CANDIDATE_TIMEOUT = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Snapshot freshness inspector
+# ---------------------------------------------------------------------------
+
+
+def device_state_looks_frozen(initial_payload: dict | None) -> bool:
+    """Return ``True`` when an ``/r/initial`` payload shows the
+    structural signature of a wrong-region cloud snapshot.
+
+    Returns ``True`` when either:
+
+    1. The payload is ``None``, lacks ``states``, or has an empty
+       ``states`` list (the cloud knows the device UUID but has no
+       data for it).
+    2. The payload contains an ``online`` state with ``vb=False``
+       **and** every entry in ``states`` shares the same numeric
+       timestamp (the cloud has only one snapshot ever recorded,
+       and the device is not online).
+
+    Returns ``False`` for the normal cases:
+
+    * A device with varied per-field timestamps — even if currently
+      offline — has history, so it's not flagged.  A genuinely-offline
+      device with a real cloud record looks different from a wrong-
+      region device whose cloud record never received updates.
+    * A device whose states all share a single timestamp **but** is
+      online (e.g. a healthy batch update event arrived a moment ago).
+
+    The rule deliberately requires both ``online=False`` and a single
+    distinct timestamp because either signal alone produces false
+    positives.  Combining them isolates the wrong-region signature
+    without depending on wall-clock thresholds or other heuristics.
+
+    Parameters
+    ----------
+    initial_payload
+        The single device's payload extracted from
+        ``response_json["deviceInfo"][0]``.  ``None`` is tolerated.
+
+    Returns
+    -------
+    bool
+        ``True`` when the snapshot looks like a wrong-region record;
+        ``False`` otherwise.  Callers typically use the ``True``
+        result to raise a Repair issue inviting the user to confirm
+        or change the configured ``cloud_region``.
+    """
+    if not isinstance(initial_payload, dict):
+        return True
+    states = initial_payload.get("states")
+    if not isinstance(states, list) or not states:
+        return True
+
+    # Look for an explicit online flag.  Absent or True -> not frozen.
+    online_value: bool | None = None
+    for state in states:
+        if isinstance(state, dict) and state.get("n") == "online":
+            vb = state.get("vb")
+            if isinstance(vb, bool):
+                online_value = vb
+            break
+    if online_value is not False:
+        return False
+
+    # Collect numeric timestamps from every state entry.  If more than
+    # one distinct value appears the device has real per-field history,
+    # which rules out a frozen-snapshot pattern.
+    distinct_timestamps: set[int] = set()
+    for state in states:
+        if not isinstance(state, dict):
+            continue
+        ts = state.get("t")
+        if isinstance(ts, int):
+            distinct_timestamps.add(ts)
+
+    return len(distinct_timestamps) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Region discovery probe
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CandidateProbe:
+    """Outcome of probing a single BlueCloud region."""
+
+    region: str
+    """Region key, e.g. ``"us"``."""
+
+    device_count: int | None = None
+    """Number of devices returned by ``/c/registered-devices``,
+    or ``None`` if the probe failed before reaching that call."""
+
+    online_count: int | None = None
+    """Number of returned devices whose ``/c/device-status`` response
+    reported ``online=True``.  ``None`` if device status was not checked."""
+
+    cloud_login_ok: bool = False
+    """Whether ``/c/login`` returned an access token for this region
+    using the current Gigya JWT."""
+
+    error: str | None = None
+    """Short reason this candidate was not probed successfully
+    (e.g. ``"timeout"``, ``"http 403"``, ``"network: <msg>"``).  ``None``
+    on success."""
+
+
+@dataclass
+class CloudRegionScan:
+    """Aggregate result of probing several BlueCloud regions."""
+
+    selected_region: str
+    """The ``cloud_region`` that was configured on the client when
+    discovery ran.  Returned untouched so callers can compare."""
+
+    candidates_tried: list[str]
+    """Ordered list of region keys actually probed."""
+
+    per_region: dict[str, CandidateProbe] = field(default_factory=dict)
+    """Detailed outcome for each candidate."""
+
+    winner: str | None = None
+    """Recommended ``cloud_region`` (most devices found; ties broken
+    in favor of ``selected_region``).  ``None`` when no candidate
+    returned any devices."""
+
+    multi_region_detected: bool = False
+    """``True`` when more than one candidate returned a non-empty
+    device list — the account owns hardware on multiple BlueCloud
+    regions.  Today's integration can only pick one; the caller is
+    expected to log a warning and surface this in diagnostics."""
+
+    @property
+    def changed(self) -> bool:
+        """Whether the recommended winner differs from ``selected_region``."""
+        return self.winner is not None and self.winner != self.selected_region
+
+
+async def _probe_candidate(
+    api: HttpAwsBlueair,
+    region: str,
+    jwt: str,
+    *,
+    timeout: float,
+) -> CandidateProbe:
+    """Run a single read-only probe against ``region``.
+
+    Uses the supplied Gigya ``jwt`` to call ``/c/login`` on the
+    candidate region's host, then ``/c/registered-devices`` with the
+    returned access token.  The candidate's access token is discarded
+    after the probe — we never persist it on ``api``.
+    """
+    probe = CandidateProbe(region=region)
+    if region not in AWS_APIKEYS:
+        probe.error = "unknown region"
+        return probe
+
+    rest_id = AWS_APIKEYS[region]["restApiId"]
+    aws_region = AWS_APIKEYS[region]["awsRegion"]
+    base = f"https://{rest_id}.execute-api.{aws_region}/prod/c"
+
+    headers = {"idtoken": jwt, "authorization": f"Bearer {jwt}"}
+
+    def _release_response(response) -> None:
+        release = getattr(response, "release", None)
+        if callable(release):
+            release()
+
+    try:
+        async with asyncio.timeout(timeout):
+            # /c/login swap (no _LOGGER.info — caller decides what to surface)
+            _LOGGER.debug("discover: probing /c/login at %s (%s)", region, rest_id)
+            login_resp = await api.api_session.post(  # type: ignore[union-attr]
+                url=f"{base}/login", headers=headers
+            )
+            if login_resp.status != 200:
+                probe.error = f"http {login_resp.status}"
+                _release_response(login_resp)
+                return probe
+            try:
+                login_json = await login_resp.json()
+            except (ValueError, ClientError):
+                # Non-JSON 200 (CloudFront error page, captive portal,
+                # truncated body, etc.).  Treat as a soft failure of
+                # this candidate so the scan can keep going.
+                probe.error = "login: non-json response"
+                return probe
+            if not isinstance(login_json, dict):
+                probe.error = "login: unexpected response shape"
+                return probe
+            access_token = login_json.get("access_token")
+            if not access_token:
+                probe.error = "no access_token in response"
+                return probe
+            probe.cloud_login_ok = True
+
+            _LOGGER.debug(
+                "discover: probing /c/registered-devices at %s", region
+            )
+            devices_resp = await api.api_session.get(  # type: ignore[union-attr]
+                url=f"{base}/registered-devices",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            if devices_resp.status != 200:
+                probe.error = f"devices http {devices_resp.status}"
+                _release_response(devices_resp)
+                return probe
+            try:
+                devices_json = await devices_resp.json()
+            except (ValueError, ClientError):
+                probe.error = "devices: non-json response"
+                return probe
+            devices = devices_json.get("devices") if isinstance(devices_json, dict) else None
+            devices = devices if isinstance(devices, list) else []
+            probe.device_count = len(devices)
+            probe.online_count = 0
+
+            for device in devices:
+                device_id = device.get("uuid") if isinstance(device, dict) else None
+                if not device_id:
+                    continue
+                try:
+                    status_resp = await api.api_session.post(  # type: ignore[union-attr]
+                        url=f"{base}/device-status",
+                        headers={"Authorization": f"Bearer {access_token}"},
+                        json={"deviceId": device_id},
+                    )
+                    if status_resp.status != 200:
+                        _release_response(status_resp)
+                        continue
+                    status_json = await status_resp.json()
+                except (ValueError, ClientError):
+                    continue
+                if isinstance(status_json, dict) and status_json.get("online") is True:
+                    probe.online_count += 1
+            return probe
+    except TimeoutError:
+        probe.error = "timeout"
+        return probe
+    except ClientError as exc:
+        probe.error = f"network: {exc}"
+        return probe
+
+
+async def discover_cloud_region(
+    api: HttpAwsBlueair,
+    *,
+    candidates: Iterable[str] | None = None,
+    per_candidate_timeout: float = _DEFAULT_PER_CANDIDATE_TIMEOUT,
+) -> CloudRegionScan:
+    """Probe candidate BlueCloud regions and return a recommendation.
+
+    Intended to be called **explicitly** by the integration layer
+    (e.g. from a config-flow "Detect cloud region" step or a Repair-
+    issue Fix dialog), not from the library's normal startup or
+    refresh paths.  The caller is expected to present the returned
+    scan to the user before persisting any change.
+
+    This routine is **read-only with respect to ``api`` state**:
+
+    * ``api.cloud_region`` is not modified.
+    * No persistent access token is written to ``api``.  The caller
+      decides whether to switch ``cloud_region`` (and clear stale
+      tokens) based on the returned :class:`CloudRegionScan`.
+
+    A valid Gigya JWT is required.  When ``api.jwt`` is unset, this
+    routine refreshes it once via the normal Gigya login flow before
+    probing candidates.
+
+    Parameters
+    ----------
+    api
+        The ``HttpAwsBlueair`` to probe with.
+    candidates
+        Region keys to probe.  Defaults to every known region in
+        ``AWS_APIKEYS``.  The client's currently selected region is
+        always probed first so the current configured choice is
+        represented first in the returned scan and in tie-breaking.
+    per_candidate_timeout
+        Per-candidate probe deadline in seconds.
+
+    Returns
+    -------
+    CloudRegionScan
+        Scan summary; see the dataclass docstring.
+    """
+    if candidates is None:
+        ordered = list(AWS_APIKEYS.keys())
+    else:
+        ordered = [c for c in candidates if c in AWS_APIKEYS]
+
+    # Probe the currently selected region first.  This preserves the
+    # configured region as the canonical answer for shared-host aliases
+    # and tie breaks, while still scanning every deduped candidate so
+    # multi-region accounts can be detected.
+    if api.cloud_region in ordered:
+        ordered.remove(api.cloud_region)
+        ordered.insert(0, api.cloud_region)
+
+    # De-duplicate by BlueCloud host: several region keys can share
+    # the same execute-api endpoint (currently ``au`` and ``eu`` both
+    # target ``hkgmr8v960.execute-api.eu-west-1``).  Probing both
+    # would double-count devices and falsely fire multi-region
+    # detection.  Keep the first occurrence so the caller's selected
+    # region wins canonicalization.
+    seen_hosts: set[tuple[str, str]] = set()
+    deduped: list[str] = []
+    for region in ordered:
+        conf = AWS_APIKEYS[region]
+        host_key = (conf["restApiId"], conf["awsRegion"])
+        if host_key in seen_hosts:
+            _LOGGER.debug(
+                "discover: skipping %s (shares BlueCloud host with an "
+                "already-queued region)",
+                region,
+            )
+            continue
+        seen_hosts.add(host_key)
+        deduped.append(region)
+    ordered = deduped
+
+    scan = CloudRegionScan(
+        selected_region=api.cloud_region,
+        candidates_tried=list(ordered),
+    )
+
+    # Ensure we have a Gigya JWT.  refresh_jwt() handles refresh_session
+    # on its own when needed.  Failures here can't be recovered by
+    # discovery and bubble up.
+    if not getattr(api, "jwt", None):
+        _LOGGER.debug("discover: refreshing Gigya JWT before probing")
+        await api.refresh_jwt()
+    jwt = api.jwt
+    if not jwt:
+        # refresh_jwt() succeeded but produced nothing -- shouldn't
+        # happen, but don't crash; return an empty scan and let the
+        # caller log if they care.
+        _LOGGER.debug("discover: no Gigya JWT after refresh; aborting probe")
+        return scan
+
+    for region in ordered:
+        probe = await _probe_candidate(api, region, jwt, timeout=per_candidate_timeout)
+        scan.per_region[region] = probe
+        if probe.error is not None:
+            _LOGGER.debug(
+                "discover: candidate %s rejected (%s)", region, probe.error
+            )
+        else:
+            _LOGGER.debug(
+                "discover: candidate %s -> %d device(s), %d online",
+                region,
+                probe.device_count or 0,
+                probe.online_count or 0,
+            )
+
+    # Pick the winner.  Online devices are the strongest signal that a
+    # BlueCloud region is the live backend for the account.  This matters
+    # because stale mirrored regions can still return the same registered
+    # device list while reporting the device offline.  If no candidate reports
+    # an online device, fall back to device count; tie -> selected region.
+    online_per_region = {
+        r: p.online_count
+        for r, p in scan.per_region.items()
+        if p.online_count and p.online_count > 0
+    }
+    devices_per_region = {
+        r: p.device_count
+        for r, p in scan.per_region.items()
+        if p.device_count and p.device_count > 0
+    }
+
+    winning_counts = online_per_region or devices_per_region
+    if winning_counts:
+        max_count = max(winning_counts.values())
+        winners = [r for r, c in winning_counts.items() if c == max_count]
+        if scan.selected_region in winners:
+            scan.winner = scan.selected_region
+        else:
+            # Preserve the order regions were probed in (selected
+            # first), so ties resolve deterministically.
+            for r in ordered:
+                if r in winners:
+                    scan.winner = r
+                    break
+        scan.multi_region_detected = len(devices_per_region) > 1
+
+    # Only emit higher than DEBUG when there's something meaningful
+    # for an operator to see.  The probe itself never switches the
+    # active region; the caller decides what (if anything) to do with
+    # the recommendation.
+    if scan.multi_region_detected:
+        _LOGGER.warning(
+            "Account has devices on multiple BlueCloud regions: %s. "
+            "The integration can only use one region per config entry; "
+            "recommending %r based on device status and count.",
+            sorted(devices_per_region),
+            scan.winner,
+        )
+    elif scan.changed:
+        _LOGGER.info(
+            "BlueCloud region discovery: %r appears to host this "
+            "account's device(s); current configured region is %r. "
+            "Caller decides whether to switch.",
+            scan.winner,
+            scan.selected_region,
+        )
+
+    return scan

--- a/src/blueair_api/util_bootstrap.py
+++ b/src/blueair_api/util_bootstrap.py
@@ -45,12 +45,17 @@ async def get_aws_devices(
     password: str,
     region: str = "us",
     client_session: ClientSession | None = None,
+    *,
+    gigya_region: str | None = None,
+    cloud_region: str | None = None,
 ) -> tuple[HttpAwsBlueair, list[DeviceAws]]:
     api = HttpAwsBlueair(
         username=username,
         password=password,
         region=region,
         client_session=client_session,
+        gigya_region=gigya_region,
+        cloud_region=cloud_region,
     )
     api_devices = await api.devices()
     devices = []

--- a/tests/test_http_aws_blueair_regions.py
+++ b/tests/test_http_aws_blueair_regions.py
@@ -1,0 +1,150 @@
+"""Tests for the gigya_region / cloud_region split on ``HttpAwsBlueair``.
+
+These verify:
+
+* Existing single-``region`` callers behave identically (back-compat).
+* ``gigya_region`` and ``cloud_region`` can be set independently.
+* Each URL builder picks up the *correct* region (Gigya hosts use
+  ``gigya_region``; BlueCloud + IoT hosts use ``cloud_region``).
+* Invalid regions raise ``ValueError`` with a clear message, both at
+  construction and via the legacy ``region`` setter.
+* The legacy ``region`` property reflects ``cloud_region`` (so
+  ``MqttAwsBlueair`` and other downstream callers see the broker
+  region, not the Gigya region).
+
+No network is required; we build the client and inspect attributes /
+constructed URLs.
+"""
+from __future__ import annotations
+
+import pytest
+
+from blueair_api.const import AWS_APIKEYS
+from blueair_api.http_aws_blueair import HttpAwsBlueair
+
+
+def _make(**kwargs) -> HttpAwsBlueair:
+    """Build a client without opening a real aiohttp session.
+
+    We pass a sentinel ``client_session`` to avoid the default
+    ``ClientSession()`` instantiation (which would leak across tests).
+    """
+    return HttpAwsBlueair(
+        username="user@example.com",
+        password="hunter2",
+        client_session=object(),  # type: ignore[arg-type]
+        **kwargs,
+    )
+
+
+class TestBackCompatSingleRegion:
+    """Existing single-``region`` callers must keep working unchanged."""
+
+    @pytest.mark.parametrize("region", sorted(AWS_APIKEYS))
+    def test_single_region_sets_both_halves(self, region: str) -> None:
+        client = _make(region=region)
+        assert client.gigya_region == region
+        assert client.cloud_region == region
+        # Legacy attribute access still works and matches cloud_region.
+        assert client.region == region
+
+    def test_default_region_is_us(self) -> None:
+        client = _make()
+        assert client.gigya_region == "us"
+        assert client.cloud_region == "us"
+        assert client.region == "us"
+
+
+class TestSplitRegions:
+    """gigya_region and cloud_region can be set independently."""
+
+    def test_split_us_gigya_eu_cloud(self) -> None:
+        client = _make(gigya_region="us", cloud_region="eu")
+        assert client.gigya_region == "us"
+        assert client.cloud_region == "eu"
+        # The back-compat ``region`` alias must point at the BlueCloud
+        # side so MQTT broker lookup picks the matching IoT endpoint.
+        assert client.region == "eu"
+
+    def test_split_only_cloud_override(self) -> None:
+        # When only cloud_region is overridden, gigya_region falls back
+        # to the ``region`` argument's value (here the default "us").
+        client = _make(cloud_region="eu")
+        assert client.gigya_region == "us"
+        assert client.cloud_region == "eu"
+
+    def test_split_only_gigya_override(self) -> None:
+        client = _make(gigya_region="eu", region="us")
+        assert client.gigya_region == "eu"
+        assert client.cloud_region == "us"
+
+    def test_explicit_args_win_over_region(self) -> None:
+        # Both halves overridden + a legacy ``region`` value passed too:
+        # the explicit overrides must win.
+        client = _make(region="us", gigya_region="eu", cloud_region="au")
+        assert client.gigya_region == "eu"
+        assert client.cloud_region == "au"
+
+
+class TestValidation:
+    """Unknown regions raise ValueError with a useful message."""
+
+    def test_unknown_region_in_legacy_arg(self) -> None:
+        with pytest.raises(ValueError, match="Unknown gigya_region"):
+            _make(region="zz")
+
+    def test_unknown_gigya_region(self) -> None:
+        with pytest.raises(ValueError, match="Unknown gigya_region"):
+            _make(gigya_region="zz")
+
+    def test_unknown_cloud_region(self) -> None:
+        with pytest.raises(ValueError, match="Unknown cloud_region"):
+            _make(cloud_region="zz")
+
+    def test_legacy_region_setter_validates(self) -> None:
+        client = _make()
+        with pytest.raises(ValueError, match="Unknown region"):
+            client.region = "zz"
+
+    def test_legacy_region_setter_keeps_halves_in_sync(self) -> None:
+        client = _make(gigya_region="us", cloud_region="eu")
+        # Reassigning via the legacy property snaps both halves
+        # back together — that's the historical behavior.
+        client.region = "au"
+        assert client.gigya_region == "au"
+        assert client.cloud_region == "au"
+
+
+class TestUrlsUseCorrectRegion:
+    """The four URL builders must pick the correct region per host."""
+
+    @staticmethod
+    def _gigya_host(client: HttpAwsBlueair) -> str:
+        return AWS_APIKEYS[client.gigya_region]["gigyaRegion"]
+
+    @staticmethod
+    def _cloud_rest_id(client: HttpAwsBlueair) -> str:
+        return AWS_APIKEYS[client.cloud_region]["restApiId"]
+
+    def test_asymmetric_hosts_are_distinct(self) -> None:
+        """Sanity: US-Gigya and EU-Cloud must resolve to different hosts.
+
+        If this ever fails it means the regional constants table has
+        drifted and the rest of the assertions in this file would be
+        meaningless.
+        """
+        client = _make(gigya_region="us", cloud_region="eu")
+        assert "us1" in self._gigya_host(client)
+        # eu rest API id is currently ``hkgmr8v960``.
+        assert self._cloud_rest_id(client).startswith("hkg")
+
+    def test_api_key_follows_gigya_region(self) -> None:
+        # Gigya partner key is part of the Gigya record; if cloud_region
+        # leaked into apikey selection we'd silently send a US key to
+        # the EU host (which the EU partner would reject with
+        # "Invalid apiKey").
+        client = _make(gigya_region="eu", cloud_region="us")
+        assert (
+            AWS_APIKEYS[client.gigya_region]["apiKey"]
+            != AWS_APIKEYS[client.cloud_region]["apiKey"]
+        )

--- a/tests/test_region_discovery.py
+++ b/tests/test_region_discovery.py
@@ -1,0 +1,544 @@
+"""Tests for ``blueair_api.region_discovery``.
+
+Covers two primitives:
+
+* ``device_state_looks_frozen`` — pure structural inspector, easy to
+    fuzz with fixture payloads.
+* ``discover_cloud_region`` — async probe, exercised with a fake
+  aiohttp session so we never hit the network and can deterministically
+  shape per-region outcomes (success, http error, timeout, etc.).
+
+The discovery probe is contract-tested for:
+
+* Read-only behavior: the client's ``cloud_region`` and persistent
+  ``access_token`` are not mutated by ``discover_cloud_region``.
+* Selected region is probed first.
+* Winner is the region with the most devices, with ties broken in
+  favor of the currently selected region.
+* Multi-region accounts are flagged and warn at WARNING+.
+* Empty / errored candidates are tolerated; an account with no
+  device anywhere produces a ``winner=None`` scan rather than
+  raising.
+* Per-candidate timeout is respected.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from unittest import IsolatedAsyncioTestCase
+
+import pytest
+
+from blueair_api.http_aws_blueair import HttpAwsBlueair
+from blueair_api.region_discovery import (
+    CloudRegionScan,
+    device_state_looks_frozen,
+    discover_cloud_region,
+)
+
+
+# ---------------------------------------------------------------------------
+# device_state_looks_frozen
+# ---------------------------------------------------------------------------
+
+
+def _states(rows: list[dict]) -> dict:
+    return {"states": rows}
+
+
+class TestDeviceStateLooksFrozen:
+    """Unit tests for the structural snapshot-frozen detector.
+
+    The rule fires only on the unambiguous wrong-region signature:
+    no states at all, OR ``online=False`` combined with every state
+    sharing a single timestamp.  Crucially, a genuinely-offline device
+    with rich per-field history is NOT flagged — that's a normal
+    offline condition, not a region issue.
+    """
+
+    def test_none_payload_is_frozen(self) -> None:
+        # Defensive: a None payload has no recorded state at all.
+        assert device_state_looks_frozen(None) is True
+
+    def test_missing_states_is_frozen(self) -> None:
+        assert device_state_looks_frozen({}) is True
+
+    def test_empty_states_is_frozen(self) -> None:
+        # The cloud knows the device UUID but has no data for it.
+        # That's a strong wrong-region signal on its own.
+        assert device_state_looks_frozen(_states([])) is True
+
+    def test_online_true_is_never_frozen(self) -> None:
+        # Even with identical timestamps, an explicitly online device
+        # is not a region-mismatch signature -- it's just a device
+        # that batch-updated all its fields at one moment.
+        payload = _states([
+            {"n": "fanspeed", "v": 11, "t": 1_700_000_000},
+            {"n": "standby", "vb": False, "t": 1_700_000_000},
+            {"n": "online", "vb": True, "t": 1_700_000_000},
+        ])
+        assert device_state_looks_frozen(payload) is False
+
+    def test_online_absent_is_never_frozen(self) -> None:
+        # No explicit online field -> we don't claim to know.
+        # Conservative: not a frozen-snapshot signature.
+        payload = _states([
+            {"n": "fanspeed", "v": 11, "t": 1_700_000_000},
+            {"n": "standby", "vb": False, "t": 1_700_000_000},
+        ])
+        assert device_state_looks_frozen(payload) is False
+
+    def test_offline_but_varied_timestamps_is_not_frozen(self) -> None:
+        # A genuinely-offline device whose fields had varied last-
+        # update times before going offline.  Real history, no
+        # region issue.
+        payload = _states([
+            {"n": "fanspeed", "v": 91, "t": 1_750_000_000},
+            {"n": "brightness", "v": 50, "t": 1_751_000_000},
+            {"n": "standby", "vb": False, "t": 1_752_000_000},
+            {"n": "online", "vb": False, "t": 1_752_000_010},
+        ])
+        assert device_state_looks_frozen(payload) is False
+
+    def test_issue_312_signature_is_frozen(self) -> None:
+        # The exact pattern from issue #312: every state, including
+        # online=False, sharing a single timestamp.
+        frozen = 1_751_231_628
+        payload = _states([
+            {"n": "fanspeed", "v": 91, "t": frozen},
+            {"n": "standby", "vb": False, "t": frozen},
+            {"n": "brightness", "v": 100, "t": frozen},
+            {"n": "automode", "vb": False, "t": frozen},
+            {"n": "online", "vb": False, "t": frozen},
+        ])
+        assert device_state_looks_frozen(payload) is True
+
+    def test_offline_with_no_numeric_timestamps_is_frozen(self) -> None:
+        # Defensive: the rule treats <= 1 distinct timestamp as the
+        # frozen-snapshot signature when combined with online=False.
+        # Zero distinct timestamps satisfies that.
+        payload = _states([
+            {"n": "fanspeed", "v": 11},
+            {"n": "online", "vb": False, "t": "not-an-int"},
+        ])
+        assert device_state_looks_frozen(payload) is True
+
+    def test_non_dict_state_entries_are_tolerated(self) -> None:
+        # Garbage entries are ignored.  The remaining valid online=True
+        # state means we don't flag this.
+        payload = _states([
+            "junk",
+            42,
+            {"n": "fanspeed", "v": 11, "t": 1_700_000_000},
+            {"n": "online", "vb": True, "t": 1_700_000_000},
+        ])
+        assert device_state_looks_frozen(payload) is False
+
+
+# ---------------------------------------------------------------------------
+# discover_cloud_region
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for aiohttp.ClientResponse for our probes.
+
+    Pass either ``body=<dict>`` for a normal JSON response, or
+    ``json_exc=<exception instance>`` to make ``.json()`` raise
+    (used to simulate non-JSON 200 responses like a CloudFront
+    error page).
+    """
+
+    def __init__(
+        self,
+        status: int,
+        body: object = None,
+        *,
+        json_exc: BaseException | None = None,
+    ) -> None:
+        self.status = status
+        self._body = body
+        self._json_exc = json_exc
+
+    async def json(self):
+        if self._json_exc is not None:
+            raise self._json_exc
+        return self._body
+
+    def release(self) -> None:
+        pass
+
+
+class _FakeSession:
+    """Async fake for ``aiohttp.ClientSession`` used by the probe.
+
+    Each candidate region maps to either a callable returning two
+    responses (``/c/login``, ``/c/registered-devices``) or to an
+    exception to raise.  This lets each test shape regions
+    independently.
+    """
+
+    def __init__(self, by_region: dict[str, object]) -> None:
+        # by_region[region] = list-of-responses OR Exception class to raise
+        self._by_region = by_region
+        self.calls: list[tuple[str, str]] = []  # (region, path)
+
+    @staticmethod
+    def _region_from_url(url: str) -> str:
+        # URLs look like
+        # https://{restApiId}.execute-api.{awsRegion}.amazonaws.com/prod/c/...
+        from blueair_api.const import AWS_APIKEYS
+
+        for region, conf in AWS_APIKEYS.items():
+            if conf["restApiId"] in url:
+                return region
+        raise AssertionError(f"could not map probe URL to region: {url}")
+
+    @staticmethod
+    def _path(url: str) -> str:
+        return url.rsplit("/prod/c/", 1)[-1]
+
+    async def _next_response(self, url: str) -> _FakeResponse:
+        region = self._region_from_url(url)
+        path = self._path(url)
+        self.calls.append((region, path))
+        entry = self._by_region.get(region)
+        if entry is None:
+            return _FakeResponse(500, {})
+        if isinstance(entry, type) and issubclass(entry, BaseException):
+            raise entry()
+        if callable(entry):
+            return entry(path)
+        # Otherwise: list[_FakeResponse], consumed in order.
+        assert isinstance(entry, list) and entry, f"empty queue for {region}"
+        return entry.pop(0)
+
+    async def post(self, *, url: str, headers=None, **kwargs):  # noqa: D401
+        return await self._next_response(url)
+
+    async def get(self, *, url: str, headers=None, **kwargs):  # noqa: D401
+        return await self._next_response(url)
+
+
+def _make_client(
+    *,
+    cloud_region: str = "us",
+    gigya_region: str = "us",
+    by_region: dict[str, object] | None = None,
+    jwt: str | None = "fake-jwt",
+) -> HttpAwsBlueair:
+    client = HttpAwsBlueair(
+        username="user@example.com",
+        password="hunter2",
+        client_session=_FakeSession(by_region or {}),  # type: ignore[arg-type]
+        gigya_region=gigya_region,
+        cloud_region=cloud_region,
+    )
+    # Skip the real Gigya login by pre-populating the JWT.
+    client.jwt = jwt
+    return client
+
+
+def _ok(devices: int, *, online: int | None = None) -> Callable[[str], _FakeResponse]:
+    """Build a fake responder that returns N devices for that region."""
+
+    online_remaining = devices if online is None else online
+
+    def responder(path: str) -> _FakeResponse:
+        nonlocal online_remaining
+        if path == "login":
+            return _FakeResponse(200, {"access_token": "fake-access-token"})
+        if path == "registered-devices":
+            return _FakeResponse(
+                200,
+                {"devices": [{"uuid": f"d{i}"} for i in range(devices)]},
+            )
+        if path == "device-status":
+            is_online = online_remaining > 0
+            if online_remaining:
+                online_remaining -= 1
+            return _FakeResponse(200, {"online": is_online})
+        return _FakeResponse(500, {})
+
+    return responder
+
+
+def _fail(login_status: int = 403) -> Callable[[str], _FakeResponse]:
+    """Build a fake responder that fails at /c/login."""
+
+    def responder(path: str) -> _FakeResponse:
+        if path == "login":
+            return _FakeResponse(login_status, {})
+        return _FakeResponse(500, {})
+
+    return responder
+
+
+class DiscoveryTest(IsolatedAsyncioTestCase):
+    async def test_winner_picks_region_with_most_devices(self) -> None:
+        # Use cn (unique host) instead of au to avoid the eu/au host
+        # collision; the dedup test covers that case explicitly.
+        client = _make_client(
+            cloud_region="us",
+            by_region={
+                "us": _ok(0),
+                "eu": _ok(1),
+                "cn": _ok(0),
+            },
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu", "cn"])
+        assert scan.winner == "eu"
+        assert scan.changed is True
+        assert scan.multi_region_detected is False
+
+    async def test_online_status_beats_stale_registered_device_mirror(self) -> None:
+        # The CP7i #312 failure mode: the stale US backend can still list
+        # the device, but /c/device-status says it is offline.  The live EU
+        # backend lists the same device and reports it online, so EU must win
+        # even though registered-device counts tie.
+        client = _make_client(
+            cloud_region="us",
+            by_region={
+                "us": _ok(1, online=0),
+                "eu": _ok(1, online=1),
+                "cn": _ok(0),
+            },
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu", "cn"])
+        assert scan.per_region["us"].device_count == 1
+        assert scan.per_region["us"].online_count == 0
+        assert scan.per_region["eu"].device_count == 1
+        assert scan.per_region["eu"].online_count == 1
+        assert scan.winner == "eu"
+        assert scan.changed is True
+
+    async def test_tie_breaks_in_favor_of_selected_region(self) -> None:
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": _ok(1), "eu": _ok(1), "cn": _ok(0)},
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu", "cn"])
+        # Both us and eu reported 1 device; us was selected, so us wins.
+        assert scan.winner == "us"
+        assert scan.changed is False
+        # But discovery still flags the multi-region condition.
+        assert scan.multi_region_detected is True
+
+    async def test_no_devices_anywhere_returns_no_winner(self) -> None:
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": _ok(0), "eu": _ok(0), "cn": _ok(0)},
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu", "cn"])
+        assert scan.winner is None
+        assert scan.changed is False
+
+    async def test_unreachable_candidates_are_skipped(self) -> None:
+        # cn raises an arbitrary exception (e.g. unreachable from caller's
+        # network); discovery must keep going and pick eu.  Use unique
+        # hosts only -- the eu/au host collision is covered by
+        # test_eu_au_host_dedup.
+        client = _make_client(
+            cloud_region="us",
+            by_region={
+                "us": _ok(0),
+                "eu": _ok(1),
+                "cn": asyncio.TimeoutError,
+            },
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu", "cn"])
+        assert scan.winner == "eu"
+        assert scan.per_region["cn"].error == "timeout"
+        assert scan.per_region["cn"].cloud_login_ok is False
+
+    async def test_eu_au_host_dedup(self) -> None:
+        """``eu`` and ``au`` share the same BlueCloud execute-api host.
+
+        Probing both would double-count devices and falsely flag a
+        multi-region account.  The dedup logic must keep only one of
+        them (the first in probe order)."""
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": _ok(0), "eu": _ok(1)},
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu", "au"])
+        # Only us and eu are actually probed; au is skipped silently.
+        assert scan.candidates_tried == ["us", "eu"]
+        assert scan.winner == "eu"
+        assert scan.multi_region_detected is False
+
+    async def test_selected_region_is_probed_first(self) -> None:
+        # Verify the call order matches: selected region (eu here)
+        # should be the first /c/login URL hit.
+        client = _make_client(
+            cloud_region="eu",
+            by_region={
+                "us": _ok(0),
+                "eu": _ok(1),
+                "cn": _ok(0),
+            },
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu", "cn"])
+        assert scan.candidates_tried[0] == "eu"
+        first_login = next(
+            call for call in client.api_session.calls if call[1] == "login"  # type: ignore[attr-defined]
+        )
+        assert first_login[0] == "eu"
+
+    async def test_does_not_mutate_client_state(self) -> None:
+        client = _make_client(
+            cloud_region="us",
+            by_region={
+                "us": _ok(0),
+                "eu": _ok(1),
+            },
+        )
+        before_cloud_region = client.cloud_region
+        before_gigya_region = client.gigya_region
+        before_access_token = client.access_token
+        await discover_cloud_region(client, candidates=["us", "eu"])
+        # The caller is the one who decides whether to switch.  The
+        # probe itself must not touch persistent client state.
+        assert client.cloud_region == before_cloud_region
+        assert client.gigya_region == before_gigya_region
+        assert client.access_token is before_access_token  # still None
+
+    async def test_unknown_candidate_keys_are_ignored(self) -> None:
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": _ok(2)},
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "zz"])
+        # "zz" is silently dropped (it's not in AWS_APIKEYS).
+        assert scan.candidates_tried == ["us"]
+        assert scan.winner == "us"
+
+    async def test_refreshes_jwt_when_missing(self) -> None:
+        # Drop the pre-seeded JWT and arrange refresh_jwt to plant one.
+        client = _make_client(
+            cloud_region="us",
+            jwt=None,
+            by_region={"us": _ok(1)},
+        )
+
+        refresh_calls: list[str] = []
+
+        async def fake_refresh_jwt() -> None:
+            refresh_calls.append("refresh_jwt")
+            client.jwt = "freshly-minted-jwt"
+
+        client.refresh_jwt = fake_refresh_jwt  # type: ignore[method-assign]
+        scan = await discover_cloud_region(client, candidates=["us"])
+        assert refresh_calls == ["refresh_jwt"]
+        assert scan.winner == "us"
+
+    async def test_multi_region_warning_is_logged(self, caplog=None) -> None:
+        # IsolatedAsyncioTestCase doesn't ship pytest's caplog fixture;
+        # capture via assertLogs instead.
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": _ok(1), "eu": _ok(2)},
+        )
+        with self.assertLogs("blueair_api.region_discovery", level="WARNING") as cm:
+            scan = await discover_cloud_region(client, candidates=["us", "eu"])
+        assert scan.multi_region_detected is True
+        # The warning explicitly names the chosen region so users in
+        # diagnostics dumps can see which region they're getting.
+        assert any("multiple BlueCloud regions" in m for m in cm.output)
+
+
+class DiscoveryQuietLoggingTest(IsolatedAsyncioTestCase):
+    """Discovery must stay at DEBUG when nothing interesting happens.
+
+    HA loads ``blueair_api`` at INFO by default.  A successful probe
+    that confirms the currently configured region must not spam the
+    log.
+    """
+
+    async def test_no_info_or_warning_when_selection_confirmed(self) -> None:
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": _ok(1), "eu": _ok(0)},
+        )
+        logger = logging.getLogger("blueair_api.region_discovery")
+        prev_level = logger.level
+        logger.setLevel(logging.INFO)
+        try:
+            # If anything at INFO+ fires, assertLogs raises AssertionError
+            # ("no logs captured for level INFO").  That's exactly what
+            # we want as a negative assertion.
+            with (
+                pytest.raises(AssertionError),
+                self.assertLogs("blueair_api.region_discovery", level="INFO"),
+            ):
+                await discover_cloud_region(client, candidates=["us", "eu"])
+        finally:
+            logger.setLevel(prev_level)
+
+
+class DiscoveryResilienceTest(IsolatedAsyncioTestCase):
+    """Probe should tolerate non-JSON / shape-malformed 200 responses.
+
+    Production failure modes seen in the wild include CloudFront
+    captive-portal interception (200 OK + HTML body) and truncated
+    transfers.  These must not crash discovery — they should record
+    a per-candidate error and let the scan keep going.
+    """
+
+    async def test_login_non_json_body_recorded_as_error(self) -> None:
+        # /c/login returns 200 with a body that ``response.json()``
+        # rejects (e.g. JSONDecodeError surfaces as ValueError).
+        def login_html_responder(path: str) -> _FakeResponse:
+            if path == "login":
+                return _FakeResponse(200, json_exc=ValueError("not json"))
+            return _FakeResponse(500)
+
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": login_html_responder, "eu": _ok(1)},
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu"])
+        # us should be marked as a soft failure with a descriptive
+        # error string; eu still wins.
+        assert scan.per_region["us"].error == "login: non-json response"
+        assert scan.per_region["us"].cloud_login_ok is False
+        assert scan.winner == "eu"
+
+    async def test_login_unexpected_shape_recorded_as_error(self) -> None:
+        # /c/login returns 200 + JSON, but it's a list instead of a dict
+        # so ``.get("access_token")`` would crash without the guard.
+        def login_list_responder(path: str) -> _FakeResponse:
+            if path == "login":
+                return _FakeResponse(200, body=["unexpected"])
+            return _FakeResponse(500)
+
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": login_list_responder, "eu": _ok(1)},
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu"])
+        assert scan.per_region["us"].error == "login: unexpected response shape"
+        assert scan.per_region["us"].cloud_login_ok is False
+        assert scan.winner == "eu"
+
+    async def test_devices_non_json_body_recorded_as_error(self) -> None:
+        # /c/login succeeds; /c/registered-devices returns 200 with a
+        # non-JSON body.  Login is marked ok but device_count stays
+        # None and the candidate cannot win.
+        def login_ok_devices_html(path: str) -> _FakeResponse:
+            if path == "login":
+                return _FakeResponse(200, body={"access_token": "tok"})
+            if path == "registered-devices":
+                return _FakeResponse(200, json_exc=ValueError("not json"))
+            return _FakeResponse(500)
+
+        client = _make_client(
+            cloud_region="us",
+            by_region={"us": login_ok_devices_html, "eu": _ok(1)},
+        )
+        scan = await discover_cloud_region(client, candidates=["us", "eu"])
+        assert scan.per_region["us"].cloud_login_ok is True
+        assert scan.per_region["us"].device_count is None
+        assert scan.per_region["us"].error == "devices: non-json response"
+        assert scan.winner == "eu"


### PR DESCRIPTION
## Summary

Adds support for accounts whose **Gigya account region** and **BlueCloud / AWS IoT
region** differ, plus **read-only diagnostic primitives** the integration layer can
call to help a user figure out which BlueCloud region their hardware actually lives
in. Closes #312.

Two self-contained commits:

1. **`split region into gigya_region and cloud_region`** — fully back-compatible
   region split.
2. **`add BlueCloud region discovery primitives`** — explicit, user-initiated
   discovery helpers that never mutate client region state on their own.

Both changes are additive. Existing single-region callers see **no behavior change**.

## Motivation

Some accounts have a US Gigya tenant but hardware provisioned against `eu-west-1`.
The previous single `region` value forced both halves to the same place, so those
devices returned frozen/empty cloud snapshots. Since we can't recover the original
provisioning region directly, this change (a) lets callers point Gigya and BlueCloud
at different regions, and (b) gives the integration a way to answer the user's
"what region am I in?" question on demand.

## What changed

### 1. Gigya / BlueCloud region split (back-compatible)

- `HttpAwsBlueair.__init__` gains keyword-only `gigya_region` and `cloud_region`.
  Both default to the legacy `region` argument, so existing call sites are unchanged.
- Gigya URL builders (`accounts.login`, `accounts.getJWT`) and the Gigya partner API
  key lookup now use `gigya_region`; all BlueCloud (`execute-api`) URLs use `cloud_region`.
- `HttpAwsBlueair.region` is now a **back-compat property** aliasing `cloud_region`,
  so downstream callers (`MqttAwsBlueair`, the HA bootstrap) that read
  `http_client.region` for the MQTT broker keep working. The setter reassigns both
  halves in lock-step.
- `util_bootstrap.get_aws_devices` forwards the new keyword args.
- Both regions are validated against `AWS_APIKEYS` at construction (and via the
  legacy setter) with a clear `ValueError`.

### 2. Read-only region discovery primitives

- `device_state_looks_frozen(payload)` — pure structural inspector for an
  `/r/initial` response. Flags the unambiguous wrong-region signature only:
  missing/empty `states`, **or** `online=False` combined with every state sharing a
  single timestamp. A genuinely offline device with real per-field history is **not**
  flagged.
- `discover_cloud_region(api)` (also `await api.discover_cloud_region()`) — async
  probe that reuses the client's Gigya JWT to call `/c/login` and
  `/c/registered-devices` on each candidate region and returns a `CloudRegionScan`
  (`selected_region`, `candidates_tried`, `per_region`, `winner`,
  `multi_region_detected`).
- New public symbols re-exported from the package root: `CandidateProbe`,
  `CloudRegionScan`, `device_state_looks_frozen`, `discover_cloud_region`.

#### Design contract

Discovery is intended to run **only on explicit user action** (config-flow "Detect
region" button, Repair-issue Fix dialog) — never from the library's normal startup
or refresh paths. The probe does **not** change the client's region selection or
device-control state (`cloud_region`, `access_token`, `user_id`, MQTT credentials).
The integration remains the policy owner: it presents the scan, the user confirms,
and the confirmed `cloud_region` is persisted so run-to-run behavior stays
deterministic.

> Note: discovery is not *entirely* side-effect-free — when no valid Gigya JWT is
> present it refreshes the Gigya session once (writes `session_token`/`session_secret`/`jwt`).
> It is therefore documented as unsafe to run concurrently with a live MQTT
> credential refresh on the **same** client instance. The HA integration avoids this
> by using a throwaway client for discovery.

#### Robustness

- Currently selected region is probed first, so the common "everything's fine" case
  finishes in one round-trip.
- Candidates are de-duplicated by BlueCloud host (the `eu`/`au` pair share
  `hkgmr8v960.execute-api.eu-west-1`), avoiding double-counting and false
  multi-region flags.
- Per-candidate timeout (default 5 s) bounds slow/unreachable regions; the initial
  Gigya JWT refresh is bounded by the same timeout.
- Non-JSON 200 bodies, unexpected JSON shapes, and unexpected exceptions are recorded
  as a per-candidate error and never abort the whole scan.
- Probes log at `DEBUG`; only meaningful outcomes (multi-region detected,
  recommended region differs) surface at `INFO`/`WARNING`, keeping HA's default log
  quiet on successful confirmations.

## Behavior changes to be aware of

- `HttpAwsBlueair.region` setter now raises `ValueError` on an unknown region value
  (previously it accepted anything). This only affects callers that reassigned
  `.region` post-construction to an invalid value.

## Testing

- Full suite: **175 passing** (`device_state_looks_frozen`, winner selection and
  tie-breaking, host dedup, JWT auto-refresh, multi-region warning, resilience to
  non-JSON/odd-shape responses, read-only contract, and the full region-split matrix).
- `ruff check` clean; `mypy` clean.
- Ran on local HA to confirm backwards compatibility.

## Notes

- No new runtime dependencies.
- Region discovery is opt-in: nothing calls it automatically. Integrations adopt it
  explicitly (see `docs/regions.md`).
