### PR TITLE
feat: add DH3i 2-in-1 combo humidification (hum_mode) and combo_mode …

### DIFF
--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -46,6 +46,8 @@ SHADOW_FIELD_MAP: dict[str, str] = {
     "wickdrys": "wick_dry_mode",
     "autorh": "auto_regulated_humidity",
     "wshortage": "water_shortage",
+    "hummode": "hum_mode",
+    "mode": "combo_mode",
     "mainmode": "main_mode",
     "heattemp": "heat_temp",
     "heatsubmode": "heat_sub_mode",
@@ -191,6 +193,16 @@ class DeviceAws(CallbacksMixin):
     water_level: AttributeType[int] = None
     auto_regulated_humidity : AttributeType[int] = None
 
+    # Combo (2-in-1 purify + humidify) controls. Present on DeviceCombo2in1
+    # devices (hw='s_cmb2in1', e.g. the DH3i). `hum_mode` is the
+    # independent humidification on/off (shadow `hummode`, writable `hm`),
+    # separate from `standby` (whole-device power) so the purifier can keep
+    # running while humidification is toggled off. `combo_mode` is the
+    # device's preset/mode selector (shadow + writable `mode`); per the
+    # firmware's Mode enum: 1=fan/manual, 2=auto, 3=night, 4=eco, 5=skin.
+    hum_mode: AttributeType[bool] = None
+    combo_mode: AttributeType[int] = None
+
     main_mode: AttributeType[int] = None # api value 0 purify only, 1 heat on, 2 cool on
     heat_sub_mode: AttributeType[int] = None # api value 1 heat on, 2 heat on with fan auto
     heat_fan_speed: AttributeType[int] = None # api value 11/37/64/91
@@ -326,6 +338,9 @@ class DeviceAws(CallbacksMixin):
         self.wick_dry_mode = states_safe_get("wickdrys")
         self.auto_regulated_humidity = states_safe_get("autorh")
         self.water_shortage = states_safe_get("wshortage")
+
+        self.hum_mode = states_safe_get("hummode")
+        self.combo_mode = states_safe_get("mode")
 
         self.main_mode = states_safe_get("mainmode")
         self.heat_temp = states_safe_get("heattemp")
@@ -494,6 +509,16 @@ class DeviceAws(CallbacksMixin):
     async def set_auto_regulated_humidity(self, value: int):
         self.auto_regulated_humidity = value
         await self.api.set_device_info(self.uuid, "autorh", "v", value)
+        self.publish_updates()
+
+    async def set_hum_mode(self, value: bool):
+        self.hum_mode = value
+        await self.api.set_device_info(self.uuid, "hummode", "vb", value)
+        self.publish_updates()
+
+    async def set_combo_mode(self, value: int):
+        self.combo_mode = value
+        await self.api.set_device_info(self.uuid, "mode", "v", value)
         self.publish_updates()
 
     async def set_child_lock(self, child_lock: bool):

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -46,7 +46,7 @@ SHADOW_FIELD_MAP: dict[str, str] = {
     "wickdrys": "wick_dry_mode",
     "autorh": "auto_regulated_humidity",
     "wshortage": "water_shortage",
-    "hummode": "hum_mode",
+    "hummode": "humidifier_mode",
     "mode": "combo_mode",
     "mainmode": "main_mode",
     "heattemp": "heat_temp",
@@ -194,13 +194,13 @@ class DeviceAws(CallbacksMixin):
     auto_regulated_humidity : AttributeType[int] = None
 
     # Combo (2-in-1 purify + humidify) controls. Present on DeviceCombo2in1
-    # devices (hw='s_cmb2in1', e.g. the DH3i). `hum_mode` is the
-    # independent humidification on/off (shadow `hummode`, writable `hm`),
+    # devices (hw='s_cmb2in1', e.g. the DH3i). `humidifier_mode` is the
+    # independent humidification on/off (shadow + writable `hummode`),
     # separate from `standby` (whole-device power) so the purifier can keep
     # running while humidification is toggled off. `combo_mode` is the
     # device's preset/mode selector (shadow + writable `mode`); per the
     # firmware's Mode enum: 1=fan/manual, 2=auto, 3=night, 4=eco, 5=skin.
-    hum_mode: AttributeType[bool] = None
+    humidifier_mode: AttributeType[bool] = None
     combo_mode: AttributeType[int] = None
 
     main_mode: AttributeType[int] = None # api value 0 purify only, 1 heat on, 2 cool on
@@ -339,7 +339,7 @@ class DeviceAws(CallbacksMixin):
         self.auto_regulated_humidity = states_safe_get("autorh")
         self.water_shortage = states_safe_get("wshortage")
 
-        self.hum_mode = states_safe_get("hummode")
+        self.humidifier_mode = states_safe_get("hummode")
         self.combo_mode = states_safe_get("mode")
 
         self.main_mode = states_safe_get("mainmode")
@@ -511,8 +511,8 @@ class DeviceAws(CallbacksMixin):
         await self.api.set_device_info(self.uuid, "autorh", "v", value)
         self.publish_updates()
 
-    async def set_hum_mode(self, value: bool):
-        self.hum_mode = value
+    async def set_humidifier_mode(self, value: bool):
+        self.humidifier_mode = value
         await self.api.set_device_info(self.uuid, "hummode", "vb", value)
         self.publish_updates()
 

--- a/tests/device_info/two_in_one_dh3i.json
+++ b/tests/device_info/two_in_one_dh3i.json
@@ -1,0 +1,383 @@
+{
+    "id": "1a1b57f1-97ea-4d7c-b687-36f71d0e6086",
+    "configuration": {
+        "di": {
+            "cfv": "1.0.6",
+            "cma": "5c:01:3b:3a:da:a0",
+            "mt": "1",
+            "name": "Master Bedroom",
+            "sku": "111811",
+            "mfv": "1.0.6",
+            "region": "en",
+            "ofv": "1.0.6",
+            "hw": "s_cmb2in1",
+            "ds": "111181100201111210007280"
+        },
+        "_ot": "CmConfig",
+        "_f": false,
+        "_it": "urn:blueair:openapi:version:cmb2in1:0.0.5",
+        "_sc": "Instance",
+        "ds": {
+            "fu0": {
+                "tf": "senml+json",
+                "ot": "filterusage",
+                "e": false,
+                "i": 0,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/s/fu0",
+                "ttl": -1,
+                "n": "fu0",
+                "fe": true
+            },
+            "yu0": {
+                "tf": "senml+json",
+                "ot": "wickusage",
+                "e": false,
+                "i": 0,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/s/yu0",
+                "ttl": -1,
+                "n": "yu0",
+                "fe": true
+            },
+            "rt5s": {
+                "tf": "senml+json",
+                "ot": "RT5s",
+                "e": false,
+                "i": 0,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/s/5s",
+                "sn": [
+                    "t",
+                    "h",
+                    "pm1",
+                    "pm2_5",
+                    "pm10",
+                    "rssi"
+                ],
+                "ttl": -1,
+                "n": "rt5s",
+                "fe": true
+            }
+        },
+        "_r": "us-east-2",
+        "_t": "Partial",
+        "_v": 1780663243,
+        "_id": "1a1b57f1-97ea-4d7c-b687-36f71d0e6086",
+        "da": {
+            "reboot": {
+                "p": false,
+                "a": false,
+                "ot": "Reboot",
+                "e": true,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/a/reboot",
+                "n": "reboot",
+                "fe": true
+            },
+            "hm": {
+                "p": true,
+                "a": false,
+                "tf": "senml+json",
+                "ot": "HumMode",
+                "e": true,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/a/hm",
+                "n": "hm",
+                "fe": true
+            },
+            "mode": {
+                "p": true,
+                "a": 0,
+                "tf": "senml+json",
+                "ot": "Mode",
+                "e": true,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/a/mode",
+                "n": "mode",
+                "fe": true
+            },
+            "sb": {
+                "p": true,
+                "a": false,
+                "tf": "senml+json",
+                "ot": "Standby",
+                "e": true,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/a/sb",
+                "n": "sb",
+                "fe": true
+            },
+            "is": {
+                "p": true,
+                "a": false,
+                "tf": "senml+json",
+                "ot": "IonizerState",
+                "e": true,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/a/is",
+                "n": "is",
+                "fe": true
+            },
+            "autorh": {
+                "p": true,
+                "a": 50,
+                "ot": "AutoRH",
+                "e": true,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/a/autorh",
+                "n": "autorh",
+                "fe": true
+            },
+            "fsp0": {
+                "p": true,
+                "st": "fsp0",
+                "a": 20,
+                "tf": "senml+json",
+                "ot": "Fanspeed",
+                "e": true,
+                "tn": "d/1a1b57f1-97ea-4d7c-b687-36f71d0e6086/a/fsp0",
+                "n": "fsp0",
+                "fe": true
+            }
+        },
+        "dc": {
+            "hummode": {
+                "a": "hm",
+                "s": "hm",
+                "t": "boolean",
+                "v": false,
+                "n": "hummode"
+            },
+            "mode": {
+                "a": "mode",
+                "s": "mode",
+                "t": "integer",
+                "v": 0,
+                "n": "mode"
+            },
+            "standby": {
+                "a": "sb",
+                "s": "sb",
+                "t": "boolean",
+                "v": false,
+                "n": "standby"
+            },
+            "filterusage": {
+                "a": "fu0",
+                "s": "fu0",
+                "t": "integer",
+                "v": 0,
+                "n": "filterusage"
+            },
+            "timl": {
+                "a": "timl",
+                "s": "timl",
+                "t": "integer",
+                "v": 0,
+                "n": "timl"
+            },
+            "timts": {
+                "a": "timts",
+                "s": "timts",
+                "t": "integer",
+                "v": 0,
+                "n": "timts"
+            },
+            "timdur": {
+                "a": "timdur",
+                "s": "timdur",
+                "t": "integer",
+                "v": 7200,
+                "n": "timdur"
+            },
+            "timstate": {
+                "a": "timstate",
+                "s": "timstate",
+                "t": "integer",
+                "v": 0,
+                "n": "timstate"
+            },
+            "wickdryl": {
+                "a": "wickdryl",
+                "s": "wickdryl",
+                "t": "integer",
+                "v": 0,
+                "n": "wickdryl"
+            },
+            "nmbrightness": {
+                "a": "nmledb",
+                "s": "nmledb",
+                "t": "integer",
+                "v": 100,
+                "n": "nmbrightness"
+            },
+            "wickdrye": {
+                "a": "wickdrye",
+                "s": "wickdrye",
+                "t": "boolean",
+                "v": false,
+                "n": "wickdrye"
+            },
+            "autorh": {
+                "a": "autorh",
+                "s": "autorh",
+                "t": "integer",
+                "v": 50,
+                "n": "autorh"
+            },
+            "brightness": {
+                "a": "ledb",
+                "s": "ledb",
+                "t": "integer",
+                "v": 100,
+                "n": "brightness"
+            },
+            "wickusage": {
+                "a": "wu0",
+                "s": "wu0",
+                "t": "integer",
+                "v": 0,
+                "n": "wickusage"
+            },
+            "childlock": {
+                "a": "chl",
+                "s": "chl",
+                "t": "boolean",
+                "v": false,
+                "n": "childlock"
+            },
+            "wickdrys": {
+                "a": "wickdrys",
+                "s": "wickdrys",
+                "t": "boolean",
+                "v": false,
+                "n": "wickdrys"
+            },
+            "wlevel": {
+                "s": "wlevel",
+                "t": "integer",
+                "v": 0,
+                "n": "wlevel"
+            },
+            "fanspeed": {
+                "a": "fsp0",
+                "s": "fsp0",
+                "t": "integer",
+                "v": 11,
+                "n": "fanspeed"
+            }
+        }
+    },
+    "alarms": [],
+    "events": [],
+    "sensordata": [],
+    "states": [
+        {
+            "n": "hummode",
+            "vb": true,
+            "t": 1780613554
+        },
+        {
+            "n": "timl",
+            "v": 0,
+            "t": 1780663243
+        },
+        {
+            "n": "timts",
+            "v": 0,
+            "t": 1780663243
+        },
+        {
+            "n": "filterusage",
+            "v": 24,
+            "t": 1780663243
+        },
+        {
+            "n": "standby",
+            "vb": false,
+            "t": 1780663243
+        },
+        {
+            "n": "timdur",
+            "v": 7200,
+            "t": 1780663243
+        },
+        {
+            "n": "wickdryl",
+            "v": 0,
+            "t": 1780663243
+        },
+        {
+            "n": "nmbrightness",
+            "v": 7,
+            "t": 1780663243
+        },
+        {
+            "n": "wickdrye",
+            "vb": true,
+            "t": 1780663243
+        },
+        {
+            "n": "autorh",
+            "v": 40,
+            "t": 1780663243
+        },
+        {
+            "n": "mode",
+            "v": 2,
+            "t": 1780662921
+        },
+        {
+            "n": "wickdryts",
+            "v": 0,
+            "t": 1780663243
+        },
+        {
+            "n": "cfv",
+            "v": 16777222,
+            "t": 1780663243
+        },
+        {
+            "n": "brightness",
+            "v": 50,
+            "t": 1780663243
+        },
+        {
+            "n": "wickusage",
+            "v": 47,
+            "t": 1780656100
+        },
+        {
+            "n": "timstate",
+            "v": 0,
+            "t": 1780663243
+        },
+        {
+            "n": "childlock",
+            "vb": true,
+            "t": 1780663243
+        },
+        {
+            "n": "mfv",
+            "v": 16777222,
+            "t": 1780663243
+        },
+        {
+            "n": "wickdrys",
+            "vb": false,
+            "t": 1780663243
+        },
+        {
+            "n": "ofv",
+            "v": 16777222,
+            "t": 1780663243
+        },
+        {
+            "n": "wlevel",
+            "v": 1,
+            "t": 1780626644
+        },
+        {
+            "n": "fanspeed",
+            "v": 11,
+            "t": 1780663243
+        },
+        {
+            "n": "online",
+            "vb": true,
+            "t": 1780663243
+        }
+    ]
+}

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -258,17 +258,17 @@ class DeviceAwsSetterTest(DeviceAwsTestBase):
         await self.device.refresh()
         assert self.device.main_mode == 2
 
-    async def test_hum_mode(self):
+    async def test_humidifier_mode(self):
         # test cache works
-        self.device.hum_mode = None
-        await self.device.set_hum_mode(False)
-        assert self.device.hum_mode is False
+        self.device.humidifier_mode = None
+        await self.device.set_humidifier_mode(False)
+        assert self.device.humidifier_mode is False
 
         # test refresh works
-        await self.device.set_hum_mode(True)
-        self.device.hum_mode = None
+        await self.device.set_humidifier_mode(True)
+        self.device.humidifier_mode = None
         await self.device.refresh()
-        assert self.device.hum_mode is True
+        assert self.device.humidifier_mode is True
 
     async def test_combo_mode(self):
         # test cache works
@@ -385,7 +385,7 @@ class EmptyDeviceAwsTest(DeviceAwsTestBase):
 
             assert UNKNOWN_MODEL in device.model_name
 
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
@@ -453,7 +453,7 @@ class H35iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Humidifier H35i"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
@@ -521,7 +521,7 @@ class H38iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair DreamWell Humidifier H38i"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
@@ -589,7 +589,7 @@ class H76iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair DreamWell Humidifier H76i"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
@@ -656,7 +656,7 @@ class Max311iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Blue Pure 311i Max"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
@@ -724,7 +724,7 @@ class T10iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair ComfortPure 3-in-1 T10i"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
@@ -799,7 +799,7 @@ class SP4iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Blue Signature SP4i"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is None
@@ -891,7 +891,7 @@ class Protect7470iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Protect 7470i"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
             assert device.pm1 == 0
             assert device.pm2_5 == 0
@@ -958,7 +958,7 @@ class Max211iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Blue Pure 211i Max"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is None
@@ -1026,7 +1026,7 @@ class PetAirProTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair PetAir Pro P3i"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is None
@@ -1094,7 +1094,7 @@ class TwoInOneTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Air Purifier + Humidifier 2-in-1 Pro"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is None
@@ -1148,7 +1148,7 @@ class TwoInOneTest(DeviceAwsTestBase):
 class Combo2in1DH3iTest(DeviceAwsTestBase):
     """Tests for the DH3i 2-in-1 Purify + Humidify combo (hw='s_cmb2in1').
 
-    This device exposes independent humidification (``hum_mode``) that is
+    This device exposes independent humidification (``humidifier_mode``) that is
     separate from whole-device power (``standby``), plus a ``combo_mode``
     preset selector. See https://github.com/dahlb/ha_blueair/issues/241.
     """
@@ -1167,7 +1167,7 @@ class Combo2in1DH3iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair 2-in-1 Purify + Humidify"
-            assert device.hum_mode is True
+            assert device.humidifier_mode is True
             assert device.combo_mode == 2
 
             assert device.pm1 is NotImplemented
@@ -1236,7 +1236,7 @@ class NullValueTest(DeviceAwsTestBase):
 
             assert device.model_name == "Blueair Mini Restful"
 
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
@@ -1309,7 +1309,7 @@ class MiniRestfulAlarmTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
             assert device.model_name == "Blueair Mini Restful"
             assert device.hw == "mrest"
-            assert device.hum_mode is NotImplemented
+            assert device.humidifier_mode is NotImplemented
             assert device.combo_mode is NotImplemented
             assert device.brightness == 40
             assert device.fan_speed == 51

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -126,6 +126,8 @@ class DeviceAwsSetterTest(DeviceAwsTestBase):
             "childlock": fake,
             "nightmode": fake,
             "wickdrys": fake,
+            "hummode": fake,
+            "mode": fake,
             "mainmode": fake,
             "heattemp": fake,
             "heatsubmode": fake,
@@ -256,6 +258,30 @@ class DeviceAwsSetterTest(DeviceAwsTestBase):
         await self.device.refresh()
         assert self.device.main_mode == 2
 
+    async def test_hum_mode(self):
+        # test cache works
+        self.device.hum_mode = None
+        await self.device.set_hum_mode(False)
+        assert self.device.hum_mode is False
+
+        # test refresh works
+        await self.device.set_hum_mode(True)
+        self.device.hum_mode = None
+        await self.device.refresh()
+        assert self.device.hum_mode is True
+
+    async def test_combo_mode(self):
+        # test cache works
+        self.device.combo_mode = None
+        await self.device.set_combo_mode(1)
+        assert self.device.combo_mode == 1
+
+        # test refresh works
+        await self.device.set_combo_mode(2)
+        self.device.combo_mode = None
+        await self.device.refresh()
+        assert self.device.combo_mode == 2
+
     async def test_heat_temp(self):
         # test cache works
         self.device.heat_temp = None
@@ -359,6 +385,9 @@ class EmptyDeviceAwsTest(DeviceAwsTestBase):
 
             assert UNKNOWN_MODEL in device.model_name
 
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
+
             assert device.pm1 is NotImplemented
             assert device.pm2_5 is NotImplemented
             assert device.pm10 is NotImplemented
@@ -424,6 +453,8 @@ class H35iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Humidifier H35i"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
             assert device.pm2_5 is NotImplemented
@@ -490,6 +521,8 @@ class H38iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair DreamWell Humidifier H38i"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
             assert device.pm2_5 is NotImplemented
@@ -556,6 +589,8 @@ class H76iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair DreamWell Humidifier H76i"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
             assert device.pm2_5 is NotImplemented
@@ -621,6 +656,8 @@ class Max311iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Blue Pure 311i Max"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
             assert device.pm2_5 is None
@@ -687,6 +724,8 @@ class T10iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair ComfortPure 3-in-1 T10i"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
             assert device.pm2_5 is None
@@ -760,6 +799,8 @@ class SP4iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Blue Signature SP4i"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is None
             assert device.pm2_5 is None
@@ -850,6 +891,8 @@ class Protect7470iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Protect 7470i"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
             assert device.pm1 == 0
             assert device.pm2_5 == 0
             assert device.pm10 == 0
@@ -915,6 +958,8 @@ class Max211iTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Blue Pure 211i Max"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is None
             assert device.pm2_5 is None
@@ -981,6 +1026,8 @@ class PetAirProTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair PetAir Pro P3i"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is None
             assert device.pm2_5 is None
@@ -1047,6 +1094,8 @@ class TwoInOneTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Air Purifier + Humidifier 2-in-1 Pro"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is None
             assert device.pm2_5 is None
@@ -1096,6 +1145,79 @@ class TwoInOneTest(DeviceAwsTestBase):
             assert device.hour_format is NotImplemented
 
 
+class Combo2in1DH3iTest(DeviceAwsTestBase):
+    """Tests for the DH3i 2-in-1 Purify + Humidify combo (hw='s_cmb2in1').
+
+    This device exposes independent humidification (``hum_mode``) that is
+    separate from whole-device power (``standby``), plus a ``combo_mode``
+    preset selector. See https://github.com/dahlb/ha_blueair/issues/241.
+    """
+
+    def setUp(self):
+        super().setUp()
+        with open(resources.files().joinpath('device_info/two_in_one_dh3i.json')) as sample_file:
+            info = json.load(sample_file)
+        self.device_info_helper.info.update(info)
+
+    async def test_attributes(self):
+
+        await self.device.refresh()
+        self.api.device_info.assert_awaited_with("fake-name-api", "fake-uuid")
+
+        with assert_fully_checked(self.device) as device:
+
+            assert device.model_name == "Blueair 2-in-1 Purify + Humidify"
+            assert device.hum_mode is True
+            assert device.combo_mode == 2
+
+            assert device.pm1 is NotImplemented
+            assert device.pm2_5 is NotImplemented
+            assert device.pm10 is NotImplemented
+            assert device.total_voc is NotImplemented
+            assert device.voc is NotImplemented
+            assert device.temperature is NotImplemented
+            assert device.humidity is NotImplemented
+            assert device.name == "Master Bedroom"
+            assert device.firmware == "1.0.6"
+            assert device.mcu_firmware == "1.0.6"
+            assert device.serial_number == "111181100201111210007280"
+            assert device.sku == "111811"
+            assert device.hw == "s_cmb2in1"
+
+            assert device.standby is False
+            assert device.night_mode is NotImplemented
+            assert device.germ_shield is NotImplemented
+            assert device.brightness == 50
+            assert device.child_lock is True
+            assert device.fan_speed == 11
+            assert device.fan_auto_mode is NotImplemented
+            assert device.filter_usage_percentage == 24
+            assert device.wifi_working is True
+            assert device.wick_usage_percentage == 47
+            assert device.auto_regulated_humidity == 40
+            assert device.water_shortage is NotImplemented
+            assert device.wick_dry_mode is False
+            assert device.main_mode is NotImplemented
+            assert device.heat_temp is NotImplemented
+            assert device.heat_sub_mode is NotImplemented
+            assert device.heat_fan_speed is NotImplemented
+            assert device.cool_sub_mode is NotImplemented
+            assert device.cool_fan_speed is NotImplemented
+            assert device.ap_sub_mode is NotImplemented
+            assert device.fan_speed_0 is NotImplemented
+            assert device.temperature_unit is NotImplemented
+            assert device.mood_brightness is NotImplemented
+            assert device.water_refresher_usage_percentage is NotImplemented
+            assert device.water_level == 1
+            assert device.rssi is NotImplemented
+            assert device.night_light_brightness is NotImplemented
+            assert device.timer_state == 0
+            assert device.timer_level == 0
+            assert device.timer_start_timestamp == 0
+            assert device.timer_duration == 7200
+            assert device.hour_format is NotImplemented
+
+
 class NullValueTest(DeviceAwsTestBase):
     """Tests for TwoInOne."""
 
@@ -1113,6 +1235,9 @@ class NullValueTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
 
             assert device.model_name == "Blueair Mini Restful"
+
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
 
             assert device.pm1 is NotImplemented
             assert device.pm2_5 is NotImplemented
@@ -1184,6 +1309,8 @@ class MiniRestfulAlarmTest(DeviceAwsTestBase):
         with assert_fully_checked(self.device) as device:
             assert device.model_name == "Blueair Mini Restful"
             assert device.hw == "mrest"
+            assert device.hum_mode is NotImplemented
+            assert device.combo_mode is NotImplemented
             assert device.brightness == 40
             assert device.fan_speed == 51
             assert device.standby is False


### PR DESCRIPTION
## Summary

Adds two new attributes to `DeviceAws` so the 2-in-1 Purify + Humidify combo
(DH3i, hardware `s_cmb2in1`) can expose humidification as a function that is
independent of whole-device power:

- **`hum_mode`** (`bool`) — humidification on/off. Reads the AWS shadow field
  `hummode`; the setter writes the device-control logical name `hummode`.
- **`combo_mode`** (`int`) — the unit's operating-mode preset selector. Reads and
  writes the shadow field `mode`. Enum: `1=Manual/Fan`, `2=Auto`, `3=Night`,
  `4=Eco`, `5=Skin`.

On this device the humidifier is a sub-function of the purifier: it is toggled
via `hummode` and is separate from `standby` (whole-device power). Today the
library has no way to represent that, which forces the integration to drive
`standby` for humidifier on/off and power the whole unit down. These attributes
give the integration a clean, independent control.

The field names and the `combo_mode` enum were determined from investigation of
the Blueair cloud API responses and AWS IoT shadow protocol behavior for this
device.

## Changes

- `device_aws.py`:
  - New fields `hum_mode: AttributeType[bool]` and `combo_mode: AttributeType[int]`.
  - `SHADOW_FIELD_MAP` entries `"hummode" -> "hum_mode"` and `"mode" -> "combo_mode"`
    (so MQTT shadow deltas update them automatically).
  - `refresh()` reads both from the device-state document.
  - Setters `set_hum_mode(bool)` (writes `hummode`) and `set_combo_mode(int)`
    (writes `mode`).
- `tests/device_info/two_in_one_dh3i.json`: new captured fixture for the DH3i.
- `tests/test_device_aws.py`:
  - New `Combo2in1DH3iTest` covering all attributes, including the two new ones.
  - `DeviceAwsSetterTest::test_hum_mode` and `::test_combo_mode`.
  - `DeviceAwsSupportsFilterResetOnlineTest::test_combo2in120_prefix_is_supported`.
  - All `assert_fully_checked` blocks updated for the two new attributes.

## Notes / scope

- The DH3i is **not** a humidifier device (`_is_humidifier` keys off
  `hw.startswith("hum")`), so its `fan_speed` stays raw and is not remapped.
- `fan_speed_count` for `s_cmb2in1` is not addressed here — the existing fallback
  is not correct for this hardware, but fixing it needs a confirmed fan-speed
  range from a real device and is deferred to the fan-preset follow-up.
- This PR intentionally only lands the data-model primitives. The consuming
  Home Assistant change (independent humidifier entity) is a separate PR in
  `dahlb/ha_blueair`.

## Testing

- `pytest tests -q` → **178 passed**
- `ruff check src/ tests/` → clean
- `mypy src/blueair_api/device_aws.py` → clean

Refs: dahlb/ha_blueair#241