### PR TITLE
feat/Use the 91-step fan scale for the 2-in-1 Purify + Humidify combos

### DIFF
--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -478,7 +478,16 @@ class DeviceAws(CallbacksMixin):
         hw = self.hw if isinstance(self.hw, str) else ""
         if self._is_humidifier:
             return 3
-        if hw.startswith("nb_") or hw.startswith("high"):
+        # The DH3i 2-in-1 Purify + Humidify (hw='s_cmb2in1') reports its
+        # manual fan speed on the same 0-91 scale as the nb_/high family:
+        # observed manual steps are 0, 11, 37, 64, 91 (the device snaps a
+        # written value to its nearest gear). Capping at 91 lets the top
+        # gear map to 100% in the UI instead of being scaled against 100.
+        if (
+            hw.startswith("nb_")
+            or hw.startswith("high")
+            or hw.startswith("s_cmb2in1")
+        ):
             return 91
         if hw.startswith("cmb3in1"):
             return 4

--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -478,15 +478,18 @@ class DeviceAws(CallbacksMixin):
         hw = self.hw if isinstance(self.hw, str) else ""
         if self._is_humidifier:
             return 3
-        # The DH3i 2-in-1 Purify + Humidify (hw='s_cmb2in1') reports its
-        # manual fan speed on the same 0-91 scale as the nb_/high family:
-        # observed manual steps are 0, 11, 37, 64, 91 (the device snaps a
-        # written value to its nearest gear). Capping at 91 lets the top
-        # gear map to 100% in the UI instead of being scaled against 100.
+        # The 2-in-1 Purify + Humidify combos belong to the same 4-gear
+        # fan-speed family as the nb_/high purifiers: manual speed runs on
+        # a 0-91 scale (gears 0, 11, 37, 64, 91; the device snaps a written
+        # value to its nearest gear). Capping at 91 lets the top gear map
+        # to 100% in the UI instead of being scaled against 100.
+        #   - s_cmb2in1  : DH3i (field-confirmed from a live fan trace)
+        #   - cmb2in1_ii : 2-in-1 Pro (same fan capability class as the DH3i)
         if (
             hw.startswith("nb_")
             or hw.startswith("high")
             or hw.startswith("s_cmb2in1")
+            or hw.startswith("cmb2in1_ii")
         ):
             return 91
         if hw.startswith("cmb3in1"):

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -1145,11 +1145,11 @@ class TwoInOneTest(DeviceAwsTestBase):
             assert device.hour_format is NotImplemented
 
     async def test_fan_speed_count(self):
-        # The Pro 2-in-1 (hw='cmb2in1_ii') is intentionally left on the
-        # default 100 scale: unlike the DH3i its fan-speed model is not
-        # field-verified to use the 0-91 gear steps.
+        # The Pro 2-in-1 (hw='cmb2in1_ii') shares the DH3i's 4-gear
+        # fan-speed class, so it uses the same 91 cap as the nb_/high
+        # family rather than the default 100.
         await self.device.refresh()
-        assert self.device.fan_speed_count == 100
+        assert self.device.fan_speed_count == 91
 
 
 class Combo2in1DH3iTest(DeviceAwsTestBase):

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -1144,6 +1144,13 @@ class TwoInOneTest(DeviceAwsTestBase):
             assert device.timer_duration == 1800
             assert device.hour_format is NotImplemented
 
+    async def test_fan_speed_count(self):
+        # The Pro 2-in-1 (hw='cmb2in1_ii') is intentionally left on the
+        # default 100 scale: unlike the DH3i its fan-speed model is not
+        # field-verified to use the 0-91 gear steps.
+        await self.device.refresh()
+        assert self.device.fan_speed_count == 100
+
 
 class Combo2in1DH3iTest(DeviceAwsTestBase):
     """Tests for the DH3i 2-in-1 Purify + Humidify combo (hw='s_cmb2in1').
@@ -1216,6 +1223,13 @@ class Combo2in1DH3iTest(DeviceAwsTestBase):
             assert device.timer_start_timestamp == 0
             assert device.timer_duration == 7200
             assert device.hour_format is NotImplemented
+
+    async def test_fan_speed_count(self):
+        # The DH3i reports its manual fan on the 0-91 gear scale (observed
+        # steps 0/11/37/64/91), so it uses the same 91 cap as the nb_/high
+        # family rather than the default 100.
+        await self.device.refresh()
+        assert self.device.fan_speed_count == 91
 
 
 class NullValueTest(DeviceAwsTestBase):


### PR DESCRIPTION
## Problem

`DeviceAws.fan_speed_count` reports how many fan gears a device exposes; the
integration uses it as the divisor when mapping a raw fan speed onto a 0–100%
UI percentage. The 2-in-1 Purify + Humidify combos were falling through to the
default `return 100`, so their **top gear capped out well below 100%** in the
UI instead of reaching full.

These combos don't run a continuous 0–100 fan. Like the `nb_` / `high`
purifiers, their manual fan moves in discrete gears on a **0–91 scale** — the
device snaps a written value to its nearest gear. With the divisor stuck at
100, the highest gear (91) showed as ~91% and the percentage steps didn't line
up with the physical gears.

## Fix

Add the two combo hardware prefixes to the existing 91-step branch in
`fan_speed_count` so they share the same gear scale as the `nb_` / `high`
family:

- **`s_cmb2in1`** — DH3i 2-in-1. Field-confirmed from a live fan trace: the
  manual gears are `0, 11, 37, 64, 91`.
- **`cmb2in1_ii`** — 2-in-1 Pro. Same fan-speed capability class as the DH3i,
  so it uses the same 91 cap. (Classification-based rather than field-confirmed
  on this specific unit, but it belongs to the same gear family.)

Result: `fan_speed_count` now returns `91` for both combos, so the top gear maps
to 100% in the UI.

```python
if (
    hw.startswith("nb_")
    or hw.startswith("high")
    or hw.startswith("s_cmb2in1")
    or hw.startswith("cmb2in1_ii")
):
    return 91
```

The 3-in-1 (`cmb3in1`) branch is intentionally left untouched — that device
doesn't expose the plain `fan_speed` attribute at all (it's `NotImplemented`
and runs its fan via the heat/cool sub-mode speeds), so its `fan_speed_count`
value isn't consumed by the standard fan path.

## Tests

- `Combo2in1DH3iTest.test_fan_speed_count` → asserts `91` (DH3i, `s_cmb2in1`).
- `TwoInOneTest.test_fan_speed_count` → updated `100` → `91` (Pro, `cmb2in1_ii`).
- Full suite: **180 passed**.
- `ruff check src/ tests/` → clean.
- `mypy src/blueair_api/device_aws.py` → clean.

## Scope / notes

- No public API change; only the gear-count value returned for these two hardware
  prefixes.
- The combo field names and gear behavior were determined from investigation of
  the Blueair cloud API responses and AWS IoT shadow protocol behavior for these
  devices.
