### PR TITLE
feat/Map firmware-version shadow fields (cfv/mfv/ofv) into DeviceAws

### DIFF
--- a/src/blueair_api/device_aws.py
+++ b/src/blueair_api/device_aws.py
@@ -64,7 +64,34 @@ SHADOW_FIELD_MAP: dict[str, str] = {
     "timts": "timer_start_timestamp",
     "timdur": "timer_duration",
     "hourformat": "hour_format",
+    # Firmware versions. REST delivers these as dotted strings; the MQTT
+    # shadow path delivers them as packed 32-bit ints (decoded on apply,
+    # see _decode_firmware_version).
+    "cfv": "firmware",
+    "mfv": "mcu_firmware",
+    "ofv": "overall_firmware",
 }
+
+# Shadow fields that carry a firmware version, needing int->str decoding.
+_FIRMWARE_SHADOW_FIELDS = frozenset({"cfv", "mfv", "ofv"})
+
+
+def _decode_firmware_version(value: Any) -> Any:
+    """Normalize a firmware version delivered by either transport.
+
+    The REST path (configuration.di.cfv/mfv/ofv) delivers a dotted string
+    like "1.0.4". The MQTT shadow path delivers the same version packed
+    into a 32-bit big-endian integer (e.g. 16777473 == 0x01000101 ->
+    "1.0.1.1"), one byte per component, most significant first.
+
+    Strings pass through unchanged; a 32-bit int is unpacked into a dotted
+    string; any other value (or an out-of-range int) is returned unchanged
+    so a version is never dropped.
+    """
+    if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 0xFFFFFFFF:
+        return ".".join(str(b) for b in value.to_bytes(4, "big"))
+    return value
+
 
 # Label map for the `apsubmode` shadow field on Signature-series air
 # purifiers (Blueair Blue Signature SP4i and related models with
@@ -163,6 +190,7 @@ class DeviceAws(CallbacksMixin):
     sku : AttributeType[str] = None
     firmware : AttributeType[str] = None
     mcu_firmware : AttributeType[str] = None
+    overall_firmware : AttributeType[str] = None
     serial_number : AttributeType[str] = None
 
     brightness : AttributeType[int] = None
@@ -248,6 +276,7 @@ class DeviceAws(CallbacksMixin):
         self.name = info_safe_get("configuration.di.name")
         self.firmware = info_safe_get("configuration.di.cfv")
         self.mcu_firmware = info_safe_get("configuration.di.mfv")
+        self.overall_firmware = info_safe_get("configuration.di.ofv")
         self.serial_number = info_safe_get("configuration.di.ds")
         self.sku = info_safe_get("configuration.di.sku")
         self.hw = info_safe_get("configuration.di.hw")
@@ -427,6 +456,8 @@ class DeviceAws(CallbacksMixin):
                     shadow_field, attr
                 )
                 continue
+            if shadow_field in _FIRMWARE_SHADOW_FIELDS:
+                value = _decode_firmware_version(value)
             try:
                 setattr(self, attr, value)
             except AttributeError:

--- a/tests/test_device_aws.py
+++ b/tests/test_device_aws.py
@@ -398,6 +398,7 @@ class EmptyDeviceAwsTest(DeviceAwsTestBase):
             assert device.name is NotImplemented
             assert device.firmware is NotImplemented
             assert device.mcu_firmware is NotImplemented
+            assert device.overall_firmware is NotImplemented
             assert device.serial_number is NotImplemented
             assert device.sku is NotImplemented
             assert device.hw is NotImplemented
@@ -466,6 +467,7 @@ class H35iTest(DeviceAwsTestBase):
             assert device.name == "Bedroom"
             assert device.firmware == "1.0.1"
             assert device.mcu_firmware == "1.0.1"
+            assert device.overall_firmware == "1.0.1"
             assert device.serial_number == "111163300201110210004036"
             assert device.sku == "111633"
             assert device.hw == "hum"
@@ -534,6 +536,7 @@ class H38iTest(DeviceAwsTestBase):
             assert device.name == "Ezra Humidifier"
             assert device.firmware == "1.0.4"
             assert device.mcu_firmware == "1.0.1"
+            assert device.overall_firmware == "1.0.4"
             assert device.serial_number == "111335300201111210008658"
             assert device.sku == "113353"
             assert device.hw == "hum2_s"
@@ -602,6 +605,7 @@ class H76iTest(DeviceAwsTestBase):
             assert device.name == "Collin’s Bedroom Humidifier "
             assert device.firmware == "1.0.4"
             assert device.mcu_firmware == "1.0.4"
+            assert device.overall_firmware == "1.0.4"
             assert device.serial_number == "111336600201110510002463"
             assert device.sku == "113366"
             assert device.hw == "hum2_l"
@@ -669,6 +673,7 @@ class Max311iTest(DeviceAwsTestBase):
             assert device.name == "Loft"
             assert device.firmware == "1.0.4"
             assert device.mcu_firmware == "1.0.4"
+            assert device.overall_firmware == "1.0.4"
             assert device.serial_number == "111082900302313210005018"
             assert device.sku == "110829"
             assert device.hw == "nb_m_1.0"
@@ -737,6 +742,7 @@ class T10iTest(DeviceAwsTestBase):
             assert device.name == "Allen's Office"
             assert device.firmware == "1.0.4"
             assert device.mcu_firmware == "1.0.4"
+            assert device.overall_firmware == "1.0.4"
             assert device.serial_number == "111212400002313210001961"
             assert device.sku == "112124"
             assert device.hw == "cmb3in1"
@@ -812,6 +818,7 @@ class SP4iTest(DeviceAwsTestBase):
             assert device.name == "Blueair SP4i"
             assert device.firmware == "1.1.0"
             assert device.mcu_firmware == "1.1.0"
+            assert device.overall_firmware == "1.1.0"
             assert device.serial_number == "112936000000000000000000"
             assert device.sku == "112936"
             assert device.hw == "l_blue40"
@@ -903,6 +910,7 @@ class Protect7470iTest(DeviceAwsTestBase):
             assert device.name == "air filter in room"
             assert device.firmware == "2.1.1"
             assert device.mcu_firmware == "1.0.12"
+            assert device.overall_firmware == "2.1.1"
             assert device.serial_number == "110582600000110110016855"
             assert device.sku == "105826"
             assert device.hw == "high_1.5"
@@ -971,6 +979,7 @@ class Max211iTest(DeviceAwsTestBase):
             assert device.name == "Bedroom Purifier"
             assert device.firmware == "1.1.6"
             assert device.mcu_firmware == "1.1.6"
+            assert device.overall_firmware == "1.1.6"
             assert device.serial_number == "111005900201111210085956"
             assert device.sku == "110059"
             assert device.hw == "nb_h_1.0"
@@ -1039,6 +1048,7 @@ class PetAirProTest(DeviceAwsTestBase):
             assert device.name == "PetAir Pro"
             assert device.firmware == "1.0.3"
             assert device.mcu_firmware == "1.0.3"
+            assert device.overall_firmware == "1.0.3"
             assert device.serial_number == "111279300002313310000090"
             assert device.sku == "112793"
             assert device.hw == "pet20"
@@ -1107,6 +1117,7 @@ class TwoInOneTest(DeviceAwsTestBase):
             assert device.name == "Master Bedroom"
             assert device.firmware == "1.1.0"
             assert device.mcu_firmware == "1.1.0"
+            assert device.overall_firmware == "1.1.0"
             assert device.serial_number == "111382500002313310004087"
             assert device.sku == "113825"
             assert device.hw == "cmb2in1_ii"
@@ -1180,6 +1191,7 @@ class Combo2in1DH3iTest(DeviceAwsTestBase):
             assert device.name == "Master Bedroom"
             assert device.firmware == "1.0.6"
             assert device.mcu_firmware == "1.0.6"
+            assert device.overall_firmware == "1.0.6"
             assert device.serial_number == "111181100201111210007280"
             assert device.sku == "111811"
             assert device.hw == "s_cmb2in1"
@@ -1249,6 +1261,7 @@ class NullValueTest(DeviceAwsTestBase):
             assert device.name == "Bedroom Air Purifier"
             assert device.firmware == "1.0.1"
             assert device.mcu_firmware == "1.2.9"
+            assert device.overall_firmware == "1.2.9"
             assert device.serial_number == "111383600201111210001674"
             assert device.sku == "113836"
             assert device.hw == "mrest"
@@ -1322,6 +1335,7 @@ class MiniRestfulAlarmTest(DeviceAwsTestBase):
             assert device.sku == "113836"
             assert device.firmware == "1.0.1"
             assert device.mcu_firmware == "1.2.9"
+            assert device.overall_firmware == "1.2.9"
             assert device.serial_number == "111383600201111210001674"
             assert device.name == "Bedroom Air Purifier"
 
@@ -1696,6 +1710,27 @@ class ApplyStateChangeTest(DeviceAwsTestBase):
             self.device.apply_state_change({"bogus": 1, "brightness": 50})
         assert self.device.brightness == 50
         assert any("no_such_attr" in msg for msg in cm.output)
+
+    async def test_firmware_version_shadow(self):
+        """cfv/mfv/ofv shadow fields update the firmware attributes."""
+        await self.device.refresh()
+        self.device.apply_state_change({
+            "cfv": 16777473,
+            "mfv": 16777473,
+            "ofv": 16777473,
+        })
+        assert self.device.firmware == "1.0.1.1"
+        assert self.device.mcu_firmware == "1.0.1.1"
+        assert self.device.overall_firmware == "1.0.1.1"
+
+    async def test_firmware_version_shadow_decoding(self):
+        """A packed 32-bit firmware int decodes to a dotted string; a
+        string passes through; an out-of-range value is left as-is."""
+        from blueair_api.device_aws import _decode_firmware_version
+        assert _decode_firmware_version(16777473) == "1.0.1.1"
+        assert _decode_firmware_version(0x02010A00) == "2.1.10.0"
+        assert _decode_firmware_version("1.0.4") == "1.0.4"
+        assert _decode_firmware_version(-1) == -1
 
 
 class MiniRestfulShadowTest(DeviceAwsTestBase):


### PR DESCRIPTION
Fixes #130.

## Problem

The `cfv`, `mfv` and `ofv` shadow fields had no `SHADOW_FIELD_MAP` entry, so
the device firmware versions only refreshed on the 5-minute REST poll, and every
MQTT shadow delta that carried them logged a `not in SHADOW_FIELD_MAP` debug line.

The three fields are the device's firmware versions:

| Shadow field | Meaning | DeviceAws attribute |
|---|---|---|
| `cfv` | Wi‑Fi / connectivity firmware version | `firmware` |
| `mfv` | MCU firmware version | `mcu_firmware` |
| `ofv` | Overall firmware version | `overall_firmware` |

## Change

- Add an `overall_firmware` attribute to `DeviceAws`.
- Map `cfv` → `firmware`, `mfv` → `mcu_firmware`, `ofv` → `overall_firmware` in
  `SHADOW_FIELD_MAP` so MQTT shadow deltas update them instantly.
- `refresh()` now reads `configuration.di.ofv` into `overall_firmware`.
- The two transports deliver these fields differently: REST returns dotted
  version strings (e.g. `"1.0.1"`), while the MQTT shadow path delivers them as
  packed 32‑bit big‑endian integers (e.g. `16777473` = `0x01000101`). A small
  `_decode_firmware_version` helper unpacks the integer form into a dotted
  string on apply (`16777473` → `"1.0.1.1"`); dotted strings pass through
  unchanged, and any other/out-of-range value is returned as‑is.

## Notes

- The shadow-decoded value is 4‑part (e.g. `"1.0.1.1"`) where the REST value is
  3‑part (e.g. `"1.0.1"`); this matches what the device actually publishes and
  is accepted per the issue.

## Tests

- New `test_firmware_version_shadow` and `test_firmware_version_shadow_decoding`.
- All 14 `assert_fully_checked` device fixtures updated for `overall_firmware`.
- 180 tests pass; `ruff` and `mypy` clean.
