### PR TITLE
fix: classify non-JSON AWS responses as SessionError instead of crashing

### DIFF
--- a/src/blueair_api/http_aws_blueair.py
+++ b/src/blueair_api/http_aws_blueair.py
@@ -50,8 +50,11 @@ def request_with_errors(func):
                     _LOGGER.debug("response json found, checking status code from response")
                     status_code = response_json["statusCode"]
         except Exception as e:
-            _LOGGER.error(f"Error parsing response for errors {e}")
-            raise e
+            _LOGGER.debug(
+                f"response body was not valid JSON (http status {status_code}), "
+                f"treating as a transient session/auth error: {e}"
+            )
+            raise SessionError(f"non-JSON response (http status {status_code})") from e
         if status_code == 200:
             _LOGGER.debug("response 200")
             return response

--- a/tests/test_http_aws_blueair_error_classification.py
+++ b/tests/test_http_aws_blueair_error_classification.py
@@ -1,0 +1,105 @@
+"""Tests for ``request_with_errors`` (the AWS response error classifier).
+
+Regression coverage for a production incident: the Blueair AWS/Cognito
+endpoints occasionally answer with an empty or otherwise non-JSON body
+(observed as a zero-byte body during a cloud-side hiccup). Before this
+fix, ``response.json()`` raised a raw ``JSONDecodeError`` that the
+wrapper re-raised as-is, bypassing its own status-code classification.
+Callers (e.g. ``ha_blueair``) only know how to retry ``ClientError``
+subclasses, so the raw parse error was a permanent, unretriable crash
+instead of a transient, retryable one.
+"""
+
+from __future__ import annotations
+
+from unittest import IsolatedAsyncioTestCase
+
+from blueair_api.errors import LoginError, SessionError
+from blueair_api.http_aws_blueair import request_with_errors
+
+
+class _FakeResponse:
+    """Minimal aiohttp.ClientResponse stand-in."""
+
+    def __init__(
+        self, status: int, body: object = None, *, json_exc: BaseException | None = None
+    ) -> None:
+        self.status = status
+        self._body = body
+        self._json_exc = json_exc
+
+    async def json(self, content_type=None):
+        if self._json_exc is not None:
+            raise self._json_exc
+        return self._body
+
+    async def text(self) -> str:
+        return "" if self._json_exc is None else "not json"
+
+
+@request_with_errors
+async def _wrapped(*, url: str, response: _FakeResponse) -> _FakeResponse:
+    return response
+
+
+class TestNonJsonResponseBody(IsolatedAsyncioTestCase):
+    """A body that fails to parse must not leak the raw parse exception."""
+
+    async def test_non_json_200_raises_session_error(self) -> None:
+        response = _FakeResponse(200, json_exc=ValueError("not json"))
+        with self.assertRaises(SessionError):
+            await _wrapped(
+                url="https://example/prod/c/registered-devices", response=response
+            )
+
+    async def test_empty_body_non_login_url_raises_session_error(self) -> None:
+        # The observed production failure: a zero-byte body during
+        # refresh_jwt(), surfaced by orjson as a JSONDecodeError.
+        response = _FakeResponse(
+            502, json_exc=ValueError("unexpected character: line 1 column 1 (char 0)")
+        )
+        with self.assertRaises(SessionError):
+            await _wrapped(
+                url="https://example/prod/c/registered-devices", response=response
+            )
+
+    async def test_empty_body_login_url_still_raises_session_error(self) -> None:
+        # Non-JSON classification happens before the login/session URL
+        # branch, so even a /accounts.login URL gets a SessionError
+        # (a ClientError subclass, still retryable) rather than a raw
+        # parse exception. It intentionally does not need to be a
+        # LoginError specifically -- the caller just needs something
+        # it knows how to retry.
+        response = _FakeResponse(400, json_exc=ValueError("not json"))
+        with self.assertRaises(SessionError):
+            await _wrapped(url="https://example/accounts.login", response=response)
+
+
+class TestExistingClassificationUnaffected(IsolatedAsyncioTestCase):
+    """Valid JSON bodies keep their pre-existing behavior."""
+
+    async def test_200_with_valid_json_returns_response(self) -> None:
+        response = _FakeResponse(200, {"ok": True})
+        result = await _wrapped(
+            url="https://example/prod/c/registered-devices", response=response
+        )
+        self.assertIs(result, response)
+
+    async def test_400_login_url_raises_login_error(self) -> None:
+        response = _FakeResponse(400, {"error": "bad credentials"})
+        with self.assertRaises(LoginError):
+            await _wrapped(url="https://example/accounts.login", response=response)
+
+    async def test_400_non_login_url_raises_session_error(self) -> None:
+        response = _FakeResponse(400, {"error": "expired"})
+        with self.assertRaises(SessionError):
+            await _wrapped(
+                url="https://example/prod/c/registered-devices", response=response
+            )
+
+    async def test_unknown_status_code_raises_value_error(self) -> None:
+        response = _FakeResponse(599, {})
+        with self.assertRaises(ValueError):
+            await _wrapped(
+                url="https://example/prod/c/registered-devices", response=response
+            )


### PR DESCRIPTION
## Problem

`request_with_errors_wrapper` in `http_aws_blueair.py` parses every AWS
response as JSON to look for an embedded `statusCode`. When that parse
fails, it re-raises the raw parse exception instead of falling back to
the status-code-based classification the rest of the function does:

```python
except Exception as e:
    _LOGGER.error(f"Error parsing response for errors {e}")
    raise e
```

That raw exception (e.g. `orjson.JSONDecodeError`) is not a `ClientError`
subclass, so callers that only know how to retry `LoginError`/`ClientError`/
`TimeoutError` (like `ha_blueair`'s `async_setup_entry`) can't tell it apart
from a genuine bug and don't retry.

## Real-world impact

Hit this in production: the AWS/Cognito token endpoint returned a
zero-byte body during a transient cloud-side hiccup while `refresh_jwt()`
was running. The raw `JSONDecodeError` propagated out of
`get_aws_devices()` uncaught, `ha_blueair`'s config entry setup failed
with a hard `SETUP_ERROR`, and — because it's not a `ConfigEntryNotReady`
— Home Assistant never retried it. Every Blueair entity sat
unavailable/failed for the rest of the day until a manual reload.

## Fix

Treat a non-JSON body as a transient/classifiable error instead of a raw
crash, and raise `SessionError` (a `ClientError` subclass, matching how
`region_discovery.py` already treats non-JSON 200 responses like
CloudFront captive-portal pages — see `DiscoveryResilienceTest`). Callers
already retry `SessionError`.

## Testing

Added `tests/test_http_aws_blueair_error_classification.py` covering the
non-JSON-body paths (200, 502-with-empty-body reproducing the exact
production error string, and a non-JSON `/accounts.login` response) plus
regression coverage that existing valid-JSON classification (`LoginError`,
`SessionError`, `ValueError` for unknown codes) is unchanged.

```
uv run pytest   # 189 passed
uv run ruff check / ruff format --check   # clean on touched lines
```
